### PR TITLE
Add string representation of Tag

### DIFF
--- a/dev_guide.md
+++ b/dev_guide.md
@@ -8,6 +8,7 @@
     - [Format Files](#format-files)
     - [Debugging Program](#debugging-program)
     - [Build Docker Image](#build-docker-image)
+    - [Additional Conventions](#additional-conventions)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -80,3 +81,9 @@ _Make use of [`build_image.sh`](./scripts/build_image.sh) to build and push (req
 cd reminder/
 . ./scripts/build_image.sh
 ```
+
+## Additional Conventions
+
+Here are some additional conventions followed:
+
+- Functions (not methods) are prefixed with `F` or `f`.

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -27,6 +27,21 @@ func TestUser(t *testing.T) {
 	utils.AssertEqual(t, got, want)
 }
 
+func TestTag(t *testing.T) {
+	// case 1: general case
+	got := models.Tag{Id: 1, Slug: "a", Group: "tag_group1"}
+	want := "tag_group1#a#1"
+	utils.AssertEqual(t, got, want)
+	// case 2: blank group
+	got = models.Tag{Id: 1, Slug: "a", Group: ""}
+	want = "#a#1"
+	utils.AssertEqual(t, got, want)
+	// case 3: omitted group
+	got = models.Tag{Id: 1, Slug: "a"}
+	want = "#a#1"
+	utils.AssertEqual(t, got, want)
+}
+
 func TestFTagsBySlug(t *testing.T) {
 	var tags []*models.Tag
 	tags = append(tags, &models.Tag{Id: 1, Slug: "a", Group: "tag_group1"})

--- a/internal/models/note.go
+++ b/internal/models/note.go
@@ -18,12 +18,6 @@ type Note struct {
 	UpdatedAt  int64    `json:"updated_at"`
 }
 
-type FNotesByUpdatedAt []*Note
-
-func (c FNotesByUpdatedAt) Len() int           { return len(c) }
-func (c FNotesByUpdatedAt) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
-func (c FNotesByUpdatedAt) Less(i, j int) bool { return c[i].UpdatedAt > c[j].UpdatedAt }
-
 // method to provide basic string representation of a note
 func (note *Note) String() []string {
 	var strs []string
@@ -67,6 +61,12 @@ func (note *Note) SearchableText() string {
 	// return searchable text for note a string
 	return strings.Join(searchable_text, " ")
 }
+
+type FNotesByUpdatedAt []*Note
+
+func (c FNotesByUpdatedAt) Len() int           { return len(c) }
+func (c FNotesByUpdatedAt) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
+func (c FNotesByUpdatedAt) Less(i, j int) bool { return c[i].UpdatedAt > c[j].UpdatedAt }
 
 // get info-texts of given notes
 func FNotesTexts(notes []*Note, max_str_len int) []string {

--- a/internal/models/tag.go
+++ b/internal/models/tag.go
@@ -16,20 +16,16 @@ type Tag struct {
 	UpdatedAt int64  `json:"updated_at"`
 }
 
+// method to provide basic string representation of a tag
+func (t Tag) String() string {
+	return fmt.Sprintf("%v#%v#%v", t.Group, t.Slug, t.Id)
+}
+
 type FTagsBySlug []*Tag
 
 func (c FTagsBySlug) Len() int           { return len(c) }
 func (c FTagsBySlug) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
 func (c FTagsBySlug) Less(i, j int) bool { return c[i].Slug < c[j].Slug }
-
-// get slugs of given tags
-func FTagsSlugs(tags []*Tag) []string {
-	var all_slugs []string
-	for _, tag := range tags {
-		all_slugs = append(all_slugs, tag.Slug)
-	}
-	return all_slugs
-}
 
 // return an array of basic tags
 // which can be used for initial setup of the application
@@ -56,6 +52,15 @@ func FBasicTags() []*Tag {
 		basic_tags = append(basic_tags, &tag)
 	}
 	return basic_tags
+}
+
+// get slugs of given tags
+func FTagsSlugs(tags []*Tag) []string {
+	var all_slugs []string
+	for _, tag := range tags {
+		all_slugs = append(all_slugs, tag.Slug)
+	}
+	return all_slugs
 }
 
 // prompt for new Tag

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -9,6 +9,7 @@ type User struct {
 	EmailId string `json:"email_id"`
 }
 
+// method to provide basic string representation of a user
 func (u User) String() string {
 	return fmt.Sprintf("{Name: %v, EmailId: %v}", u.Name, u.EmailId)
 }


### PR DESCRIPTION
### Description

Add string representation of Tag

### Tasks

 - [ ] TODO items before it can be reviewed or merged
 - [ ] Another TODO item.

### Risks

- **Low**: Adding string representation of Tag, without change in existing functionality.
- Notes for Support:
- Notes for QA:
