### PR TITLE
Fix non-static search prompt

### DIFF
--- a/cmd/reminder/main.go
+++ b/cmd/reminder/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/manifoldco/promptui"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -10,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/manifoldco/promptui"
 
 	"reminder/internal/models"
 	"reminder/pkg/utils"
@@ -146,7 +147,7 @@ func flow() {
 		// display prompt
 		prompt := promptui.Select{
 			Label:             "Notes",
-			Items:             allTexts,
+			Items:             utils.ChopStrings(allTexts, 125),
 			Size:              25,
 			StartInSearchMode: true,
 			Searcher:          searchNotes,

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -198,7 +198,7 @@ func TestFMakeSureFileExists(t *testing.T) {
 	// make sure that the existing file is not replaced
 	modificationTime := stats.ModTime()
 	// attempt to create the file and required dirs, when the file does exist already
-	time.Sleep(1 * time.Second)
+	time.Sleep(10 * time.Millisecond)
 	models.FMakeSureFileExists(dataFilePath)
 	utils.AssertEqual(t, err != nil, false)
 	utils.AssertEqual(t, errors.Is(err, fs.ErrNotExist), false)

--- a/internal/models/note.go
+++ b/internal/models/note.go
@@ -2,8 +2,9 @@ package models
 
 import (
 	"fmt"
-	"github.com/manifoldco/promptui"
 	"strings"
+
+	"github.com/manifoldco/promptui"
 
 	"reminder/pkg/utils"
 )

--- a/pkg/utils/functions.go
+++ b/pkg/utils/functions.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"errors"
 	"fmt"
-	"github.com/manifoldco/promptui"
 	"os"
 	"os/exec"
 	"reflect"
@@ -11,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/manifoldco/promptui"
 )
 
 // fmt.Sprintf("%v %v", Symbols["tag"], "Update tags"):
@@ -130,6 +131,24 @@ func TrimString(str string) string {
 	return strings.TrimSpace(str)
 }
 
+// return a chopped strings (to a desired length)
+func ChopStrings(texts []string, length int) []string {
+	// return original texts (actually copy of what was passed)
+	// if length value is not positive (considert ".." at the end)
+	if length <= 2 {
+		return texts
+	}
+	choppedStrings := []string{}
+	for _, str := range texts {
+		if len(str) <= length {
+			choppedStrings = append(choppedStrings, str)
+		} else {
+			choppedStrings = append(choppedStrings, str[0:length-2] + "..")
+		}
+	}
+	return choppedStrings
+}
+
 // validate that input is string
 func ValidateString(input string) error {
 	return nil
@@ -159,7 +178,7 @@ func ValidateDateString(input string) error {
 // display spinner
 func Spinner(delay time.Duration) {
 	for {
-		for _, c := range `-\|/` {
+		for _, c := range `–\|/` {
 			fmt.Printf("\r%c", c)
 			time.Sleep(delay)
 		}

--- a/pkg/utils/functions_test.go
+++ b/pkg/utils/functions_test.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"testing"
 	"time"
+
 	// "github.com/golang/mock/gomock"
 
 	utils "reminder/pkg/utils"
@@ -106,6 +107,18 @@ func TestTrimString(t *testing.T) {
 	utils.AssertEqual(t, utils.TrimString("   str"), "str")
 	utils.AssertEqual(t, utils.TrimString("str   "), "str")
 	utils.AssertEqual(t, utils.TrimString("  str "), "str")
+}
+
+func TestChopStrings(t *testing.T) {
+	strings := []string{"0123456789", "ABCDEFG", "0123"}
+	utils.AssertEqual(t, utils.ChopStrings(strings, 2), strings)
+	utils.AssertEqual(t, utils.ChopStrings(strings, 1), strings)
+	utils.AssertEqual(t, utils.ChopStrings(strings, 0), strings)
+	utils.AssertEqual(t, utils.ChopStrings(strings, -1), strings)
+	want := []string{"012..", "ABC..", "0123"}
+	utils.AssertEqual(t, utils.ChopStrings(strings, 5), want)
+	want = []string{"0123456..", "ABCDEFG", "0123"}
+	utils.AssertEqual(t, utils.ChopStrings(strings, 9), want)
 }
 
 func TestValidateString(t *testing.T) {


### PR DESCRIPTION
### Description

Fix https://github.com/goyalmunish/reminder/issues/18

Issue: Adding character to the search field, displays a new search field unless the search field is already at bottom of the terminal window. So, the search prompt doesn't remain on the same position.
Reason: This was happening text lines overflowing the terminal width

### Tasks

 - [ ] TODO items before it can be reviewed or merged
 - [ ] Another TODO item.

### Risks

- **Low**: Impacts only search functionality
- Notes for Support:
- Notes for QA:
