### PR TITLE
Refactor FNewTag to remove its dependency on promptui.Prompt

### DIFF
--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -18,6 +18,23 @@ import (
 	utils "reminder/pkg/utils"
 )
 
+// mocks
+
+type MockPromptTagSlug struct {
+}
+type MockPromptTagGroup struct {
+}
+
+func (prompt *MockPromptTagSlug) Run() (string, error) {
+	return "test_tag_slug", nil
+}
+
+func (prompt *MockPromptTagGroup) Run() (string, error) {
+	return "test_tag_group", nil
+}
+
+// test examples
+
 func TestDataFile(t *testing.T) {
 	defaultDataFilePath := models.FDefaultDataFile()
 	utils.AssertEqual(t, strings.HasPrefix(defaultDataFilePath, "/"), true)
@@ -618,4 +635,16 @@ Stats of "temp_test_dir/mydata.json"
   - Pending Notes: 0/0
 `
 	utils.AssertEqual(t, got, want)
+}
+
+func TestFNewTag(t *testing.T) {
+	mockPromptTagSlug := &MockPromptTagSlug{}
+	mockPromptTagGroup := &MockPromptTagGroup{}
+	tag, _ := models.FNewTag(10, mockPromptTagSlug, mockPromptTagGroup)
+	want := models.Tag{
+		Id:    10,
+		Slug:  "test_tag_slug",
+		Group: "test_tag_group",
+	}
+	utils.AssertEqual(t, tag, want)
 }

--- a/internal/models/prompt_interfaces.go
+++ b/internal/models/prompt_interfaces.go
@@ -1,0 +1,5 @@
+package models
+
+type PromptInf interface {
+	Run() (string, error)
+}

--- a/internal/models/reminder_data.go
+++ b/internal/models/reminder_data.go
@@ -145,7 +145,19 @@ func (reminderData *ReminderData) RegisterBasicTags() {
 func (reminderData *ReminderData) NewTagRegistration() (int, error) {
 	// collect and ask info about the tag
 	tagID := reminderData.nextPossibleTagId()
-	tag, err := FNewTag(tagID)
+
+	var promptTagSlug = &promptui.Prompt{
+		Label:    "Tag Slug",
+		Validate: utils.ValidateNonEmptyString,
+	}
+
+	var promptTagGroup = &promptui.Prompt{
+		Label:    "Tag Group",
+		Validate: utils.ValidateString,
+	}
+
+	tag, err := FNewTag(tagID, promptTagSlug, promptTagGroup)
+
 	// validate and save data
 	if err == nil {
 		err, _ = reminderData.newTagAppend(tag), tagID

--- a/internal/models/tag.go
+++ b/internal/models/tag.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/manifoldco/promptui"
-
 	"reminder/pkg/utils"
 )
 
@@ -103,7 +101,7 @@ func FBasicTags() Tags {
 }
 
 // prompt for new Tag
-func FNewTag(tagID int) (*Tag, error) {
+func FNewTag(tagID int, promptTagSlug PromptInf, promptTagGroup PromptInf) (*Tag, error) {
 	tag := &Tag{
 		Id:        tagID,
 		CreatedAt: utils.CurrentUnixTimestamp(),
@@ -112,11 +110,7 @@ func FNewTag(tagID int) (*Tag, error) {
 		// Group:     tagGroup,
 	}
 	// ask for tag slug
-	prompt := promptui.Prompt{
-		Label:    "Tag Slug",
-		Validate: utils.ValidateNonEmptyString,
-	}
-	tagSlug, err := prompt.Run()
+	tagSlug, err := promptTagSlug.Run()
 	tag.Slug = utils.TrimString(tagSlug)
 	tag.Slug = strings.ToLower(tag.Slug)
 	// in case of error or Ctrl-c as input, don't create the tag
@@ -129,12 +123,8 @@ func FNewTag(tagID int) (*Tag, error) {
 		err := errors.New("Tag's slug is empty")
 		return tag, err
 	}
-	prompt = promptui.Prompt{
-		Label:    "Tag Group",
-		Validate: utils.ValidateString,
-	}
 	// ask for tag's group
-	tagGroup, err := prompt.Run()
+	tagGroup, err := promptTagGroup.Run()
 	if err != nil {
 		return tag, err
 	}


### PR DESCRIPTION
### Description

Refactor FNewTag to remove its dependency on promptui.Prompt

### Tasks

 - [ ] TODO items before it can be reviewed or merged
 - [ ] Another TODO item.

### Risks

- **Low**: Tag creation might fail.
- Notes for Support:
- Notes for QA:
