### PR TITLE
Remove prompt generation from reminder_data

### DIFF
--- a/cmd/reminder/main.go
+++ b/cmd/reminder/main.go
@@ -37,6 +37,8 @@ func flow() {
 		fmt.Sprintf("%v %v", utils.Symbols["clip"], "Register Basic Tags"),
 		fmt.Sprintf("%v %v", utils.Symbols["backup"], "Create Backup"),
 		fmt.Sprintf("%v %v", utils.Symbols["pad"], "Display Data File")}, "Select Option")
+	promptTagSlug := models.GeneratePrompt("tag_slug", "")
+	promptTagGroup := models.GeneratePrompt("tag_group", "")
 	// operate on main options
 	switch result {
 	case fmt.Sprintf("%v %v", utils.Symbols["spark"], "List Stuff"):
@@ -48,19 +50,19 @@ func flow() {
 		if tagIndex != -1 {
 			if tagIndex == len(reminderData.SortedTagSlugs()) {
 				// add new tag
-				_, _ = reminderData.NewTagRegistration()
+				_, _ = reminderData.NewTagRegistration(promptTagSlug, promptTagGroup)
 			} else {
 				tag := reminderData.Tags[tagIndex]
 				notes := reminderData.FindNotes(tag.Id, "pending")
-				err := reminderData.PrintNotesAndAskOptions(notes, tag.Id)
+				err := reminderData.PrintNotesAndAskOptions(notes, tag.Id, promptTagSlug, promptTagGroup)
 				utils.PrintErrorIfPresent(err)
 			}
 		}
 	case fmt.Sprintf("%v %v", utils.Symbols["clip"], "Add Note"):
-		tagIDs := reminderData.AskTagIds([]int{})
+		tagIDs := reminderData.AskTagIds([]int{}, promptTagSlug, promptTagGroup)
 		_, _ = reminderData.NewNoteRegistration(tagIDs)
 	case fmt.Sprintf("%v %v", utils.Symbols["clip"], "Add Tag"):
-		_, _ = reminderData.NewTagRegistration()
+		_, _ = reminderData.NewTagRegistration(promptTagSlug, promptTagGroup)
 	case fmt.Sprintf("%v %v", utils.Symbols["clip"], "Register Basic Tags"):
 		reminderData.RegisterBasicTags()
 	case fmt.Sprintf("%v %v", utils.Symbols["clock"], "Pending Notes"):
@@ -115,13 +117,13 @@ func flow() {
 		fmt.Println("  - within a week or already crossed (for non repeat-annually or repeat-monthly)")
 		fmt.Println("  - within a week for repeat-annually and 2 days post due date (ignoring its year)")
 		fmt.Println("  - within 3 days for repeat-monthly and 2 days post due date (ignoring its year and month)")
-		err := reminderData.PrintNotesAndAskOptions(currentNotes, -1)
+		err := reminderData.PrintNotesAndAskOptions(currentNotes, -1, promptTagSlug, promptTagGroup)
 		utils.PrintErrorIfPresent(err)
 	case fmt.Sprintf("%v %v", utils.Symbols["done"], "Done Notes"):
 		allNotes := reminderData.Notes
 		doneNotes := allNotes.WithStatus("done")
 		fmt.Printf("A total of %v notes marked as 'done':\n", len(doneNotes))
-		err := reminderData.PrintNotesAndAskOptions(doneNotes, -1)
+		err := reminderData.PrintNotesAndAskOptions(doneNotes, -1, promptTagSlug, promptTagGroup)
 		utils.PrintErrorIfPresent(err)
 	case fmt.Sprintf("%v %v", utils.Symbols["search"], "Search Notes"):
 		// get texts of all notes
@@ -146,7 +148,7 @@ func flow() {
 		utils.PrintErrorIfPresent(err)
 		if index >= 0 {
 			note := allNotes[index]
-			reminderData.PrintNoteAndAskOptions(note)
+			reminderData.PrintNoteAndAskOptions(note, promptTagSlug, promptTagGroup)
 		}
 	case fmt.Sprintf("%v %v", utils.Symbols["backup"], "Create Backup"):
 		reminderData.CreateBackup()

--- a/cmd/reminder/main.go
+++ b/cmd/reminder/main.go
@@ -39,6 +39,7 @@ func flow() {
 		fmt.Sprintf("%v %v", utils.Symbols["pad"], "Display Data File")}, "Select Option")
 	promptTagSlug := models.GeneratePrompt("tag_slug", "")
 	promptTagGroup := models.GeneratePrompt("tag_group", "")
+	promptNoteText := models.GeneratePrompt("note_text", "")
 	// operate on main options
 	switch result {
 	case fmt.Sprintf("%v %v", utils.Symbols["spark"], "List Stuff"):
@@ -54,13 +55,13 @@ func flow() {
 			} else {
 				tag := reminderData.Tags[tagIndex]
 				notes := reminderData.FindNotes(tag.Id, "pending")
-				err := reminderData.PrintNotesAndAskOptions(notes, tag.Id, promptTagSlug, promptTagGroup)
+				err := reminderData.PrintNotesAndAskOptions(notes, tag.Id, promptTagSlug, promptTagGroup, promptNoteText)
 				utils.PrintErrorIfPresent(err)
 			}
 		}
 	case fmt.Sprintf("%v %v", utils.Symbols["clip"], "Add Note"):
 		tagIDs := reminderData.AskTagIds([]int{}, promptTagSlug, promptTagGroup)
-		_, _ = reminderData.NewNoteRegistration(tagIDs)
+		_, _ = reminderData.NewNoteRegistration(tagIDs, promptNoteText)
 	case fmt.Sprintf("%v %v", utils.Symbols["clip"], "Add Tag"):
 		_, _ = reminderData.NewTagRegistration(promptTagSlug, promptTagGroup)
 	case fmt.Sprintf("%v %v", utils.Symbols["clip"], "Register Basic Tags"):
@@ -117,13 +118,13 @@ func flow() {
 		fmt.Println("  - within a week or already crossed (for non repeat-annually or repeat-monthly)")
 		fmt.Println("  - within a week for repeat-annually and 2 days post due date (ignoring its year)")
 		fmt.Println("  - within 3 days for repeat-monthly and 2 days post due date (ignoring its year and month)")
-		err := reminderData.PrintNotesAndAskOptions(currentNotes, -1, promptTagSlug, promptTagGroup)
+		err := reminderData.PrintNotesAndAskOptions(currentNotes, -1, promptTagSlug, promptTagGroup, promptNoteText)
 		utils.PrintErrorIfPresent(err)
 	case fmt.Sprintf("%v %v", utils.Symbols["done"], "Done Notes"):
 		allNotes := reminderData.Notes
 		doneNotes := allNotes.WithStatus("done")
 		fmt.Printf("A total of %v notes marked as 'done':\n", len(doneNotes))
-		err := reminderData.PrintNotesAndAskOptions(doneNotes, -1, promptTagSlug, promptTagGroup)
+		err := reminderData.PrintNotesAndAskOptions(doneNotes, -1, promptTagSlug, promptTagGroup, promptNoteText)
 		utils.PrintErrorIfPresent(err)
 	case fmt.Sprintf("%v %v", utils.Symbols["search"], "Search Notes"):
 		// get texts of all notes

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -643,6 +643,9 @@ Stats of "temp_test_dir/mydata.json"
 	utils.AssertEqual(t, got, want)
 }
 
+func TestNewTagRegistration(t *testing.T) {
+}
+
 func TestFNewTag(t *testing.T) {
 	mockPromptTagSlug := &MockPromptTagSlug{}
 	mockPromptTagGroup := &MockPromptTagGroup{}

--- a/internal/models/reminder_data.go
+++ b/internal/models/reminder_data.go
@@ -184,12 +184,11 @@ func (reminderData *ReminderData) newTagAppend(tag *Tag) error {
 }
 
 // register new note
-func (reminderData *ReminderData) NewNoteRegistration(tagIDs []int) (*Note, error) {
+func (reminderData *ReminderData) NewNoteRegistration(tagIDs []int, promptNoteText PromptInf) (*Note, error) {
 	// collect info about the note
 	if tagIDs == nil {
 		tagIDs = []int{}
 	}
-	promptNoteText := GeneratePrompt("note_text", "")
 	note, err := FNewNote(tagIDs, promptNoteText)
 	// validate and save data
 	if err == nil {
@@ -363,7 +362,7 @@ func (reminderData *ReminderData) PrintNoteAndAskOptions(note *Note, promptTagSl
 }
 
 // method (recursively) to print notes interactively
-func (reminderData *ReminderData) PrintNotesAndAskOptions(notes Notes, tagID int, promptTagSlug PromptInf, promptTagGroup PromptInf) error {
+func (reminderData *ReminderData) PrintNotesAndAskOptions(notes Notes, tagID int, promptTagSlug PromptInf, promptTagGroup PromptInf, promptNoteText PromptInf) error {
 	// sort notes
 	sort.Sort(Notes(notes))
 	texts := notes.ExternalTexts(utils.TerminalWidth() - 50)
@@ -377,12 +376,12 @@ func (reminderData *ReminderData) PrintNotesAndAskOptions(notes Notes, tagID int
 	if noteIndex == len(texts) {
 		// add new note
 		if tagID >= 0 {
-			note, err := reminderData.NewNoteRegistration([]int{tagID})
+			note, err := reminderData.NewNoteRegistration([]int{tagID}, promptNoteText)
 			if err == nil {
 				var updatedNotes Notes
 				updatedNotes = append(updatedNotes, note)
 				updatedNotes = append(updatedNotes, notes...)
-				reminderData.PrintNotesAndAskOptions(updatedNotes, tagID, promptTagSlug, promptTagGroup)
+				reminderData.PrintNotesAndAskOptions(updatedNotes, tagID, promptTagSlug, promptTagGroup, promptNoteText)
 			}
 			utils.PrintErrorIfPresent(err)
 		} else {
@@ -393,7 +392,7 @@ func (reminderData *ReminderData) PrintNotesAndAskOptions(notes Notes, tagID int
 		note := notes[noteIndex]
 		action := reminderData.PrintNoteAndAskOptions(note, promptTagSlug, promptTagGroup)
 		if action == "stay" {
-			reminderData.PrintNotesAndAskOptions(notes, tagID, promptTagSlug, promptTagGroup)
+			reminderData.PrintNotesAndAskOptions(notes, tagID, promptTagSlug, promptTagGroup, promptNoteText)
 		}
 	}
 	return nil


### PR DESCRIPTION
### Description

Remove prompt generation from reminder_data

### Tasks

 - [ ] TODO items before it can be reviewed or merged
 - [ ] Another TODO item.

### Risks

- **High**: This involves major change. Some untested functionality might break.
- Notes for Support:
- Notes for QA:
