### PR TITLE
Enhance user workflow

### DIFF
--- a/cmd/reminder/main.go
+++ b/cmd/reminder/main.go
@@ -25,7 +25,7 @@ func flow() {
 	// TEST CODE ENDS ------>
 	// ask the main menu
 	fmt.Println("| =========================== MAIN MENU =========================== |")
-	fmt.Println("|    Use 'Ctrl-c' to jump from any nested level to the Main Menu    |")
+	fmt.Println("|    Use 'Ctrl-c' to jump one level up (towards the Main Menu)    |")
 	fmt.Println("| ----------------------------------------------------------------- |")
 	_, result := utils.AskOption([]string{fmt.Sprintf("%v %v", utils.Symbols["spark"], "List Stuff"),
 		fmt.Sprintf("%v %v %v", utils.Symbols["checkerdFlag"], "Exit", utils.Symbols["redFlag"]),

--- a/internal/models/reminder_data.go
+++ b/internal/models/reminder_data.go
@@ -372,7 +372,7 @@ func (reminderData *ReminderData) PrintNotesAndAskOptions(notes Notes, tagID int
 	texts := notes.ExternalTexts(utils.TerminalWidth() - 50)
 	// ask user to select a note
 	fmt.Println("Note: An added note appears immidiately, but if a note is moved, refresh the list by going to main menu and come back.")
-	noteIndex, _ := utils.AskOption(append(texts, fmt.Sprintf("%v %v", utils.Symbols["add"], "Add Note")), "Select Note")
+	noteIndex, _ := utils.AskOption(append(texts, fmt.Sprintf("%v %v", utils.Symbols["add"], "Add Note")), fmt.Sprintf("Select Note for the tag %v %v", utils.Symbols["tag"], reminderData.Tags[tagID].Slug))
 	if noteIndex == -1 {
 		return errors.New("The noteIndex is invalid!")
 	}

--- a/internal/models/reminder_data.go
+++ b/internal/models/reminder_data.go
@@ -313,17 +313,23 @@ func (reminderData *ReminderData) AskTagIds(tagIDs []int) []int {
 // method to print note and display options
 func (reminderData *ReminderData) PrintNoteAndAskOptions(note *Note) string {
 	fmt.Print(note.ExternalText(reminderData))
-	_, noteOption := utils.AskOption([]string{fmt.Sprintf("%v %v", utils.Symbols["noAction"], "Do nothing"),
+	_, noteOption := utils.AskOption([]string{fmt.Sprintf("%v %v", utils.Symbols["comment"], "Add comment"),
+		fmt.Sprintf("%v %v", utils.Symbols["noAction"], "Do nothing"),
 		fmt.Sprintf("%v %v", utils.Symbols["home"], "Exit to main menu"),
 		fmt.Sprintf("%v %v", utils.Symbols["upVote"], "Mark as done"),
 		fmt.Sprintf("%v %v", utils.Symbols["downVote"], "Mark as pending"),
 		fmt.Sprintf("%v %v", utils.Symbols["calendar"], "Update due date"),
-		fmt.Sprintf("%v %v", utils.Symbols["comment"], "Add comment"),
 		fmt.Sprintf("%v %v", utils.Symbols["tag"], "Update tags"),
 		fmt.Sprintf("%v %v", utils.Symbols["text"], "Update text")},
 		"Select Action")
 	fmt.Println("Do you want to update the note?")
 	switch noteOption {
+	case fmt.Sprintf("%v %v", utils.Symbols["comment"], "Add comment"):
+		promptCommment := utils.GeneratePrompt("note_comment", "")
+		promptText, err := promptCommment.Run()
+		utils.PrintErrorIfPresent(err)
+		reminderData.AddNoteComment(note, promptText)
+		fmt.Print(note.ExternalText(reminderData))
 	case fmt.Sprintf("%v %v", utils.Symbols["noAction"], "Do nothing"):
 		fmt.Println("No changes made")
 		fmt.Print(note.ExternalText(reminderData))
@@ -340,12 +346,6 @@ func (reminderData *ReminderData) PrintNoteAndAskOptions(note *Note) string {
 		promptText, err := promptCompleteBy.Run()
 		utils.PrintErrorIfPresent(err)
 		reminderData.UpdateNoteCompleteBy(note, promptText)
-		fmt.Print(note.ExternalText(reminderData))
-	case fmt.Sprintf("%v %v", utils.Symbols["comment"], "Add comment"):
-		promptCommment := utils.GeneratePrompt("note_comment", "")
-		promptText, err := promptCommment.Run()
-		utils.PrintErrorIfPresent(err)
-		reminderData.AddNoteComment(note, promptText)
 		fmt.Print(note.ExternalText(reminderData))
 	case fmt.Sprintf("%v %v", utils.Symbols["text"], "Update text"):
 		promptNoteTextWithDefault := utils.GeneratePrompt("note_text", note.Text)


### PR DESCRIPTION
### Description

- Add the current tag name (slug) to the list of notes screen. This is helpful when coming out of a particular note using "Control + c" so that the user knows which tag she/he is in currently.
- Promote "Add comment" option as the first option. This will make it easier while taking down minutes of a meeting, where multiple comments are to be added regarding a single topic.

### Tasks

 - [ ] TODO items before it can be reviewed or merged
 - [ ] Another TODO item.

### Risks

- **Low**: Changes have been tested, and no issues are expected. At max, the action of some options might get interchange.
- Notes for Support:
- Notes for QA:
