### PR TITLE
Allow empty user name and email

### DIFF
--- a/pkg/utils/functions.go
+++ b/pkg/utils/functions.go
@@ -300,13 +300,13 @@ func GeneratePrompt(promptName string, defaultText string) *promptui.Prompt {
 		prompt = &promptui.Prompt{
 			Label:    "User Name",
 			Default:  defaultText,
-			Validate: ValidateNonEmptyString,
+			Validate: ValidateString,
 		}
 	case "user_email":
 		prompt = &promptui.Prompt{
 			Label:    "User Email",
 			Default:  defaultText,
-			Validate: ValidateNonEmptyString,
+			Validate: ValidateString,
 		}
 	case "tag_slug":
 		prompt = &promptui.Prompt{


### PR DESCRIPTION
### Description

Allow empty user name and email

### Tasks

 - [ ] TODO items before it can be reviewed or merged
 - [ ] Another TODO item.

### Risks

- **Low**: User registration might fail.
- Notes for Support:
- Notes for QA:
