### PR TITLE
Change date format to DD-MM-YYYY

### DIFF
--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -359,7 +359,7 @@ func TestUpdateCompleteBy(t *testing.T) {
 	utils.AssertEqual(t, note1.CompleteBy, 0)
 	// update complete_by
 	// case 1
-	err := note1.UpdateCompleteBy("2021-12-15")
+	err := note1.UpdateCompleteBy("15-12-2021")
 	utils.AssertEqual(t, err, nil)
 	utils.AssertEqual(t, note1.CompleteBy, 1639526400)
 	// case 2

--- a/internal/models/note.go
+++ b/internal/models/note.go
@@ -113,8 +113,7 @@ func (note *Note) UpdateCompleteBy(text string) error {
 		fmt.Println("Cleared the due date from the note")
 		return nil
 	} else {
-		// fmt.Println(text)
-		format := "2006-1-2"
+		format := "2-1-2006"
 		timeValue, _ := time.Parse(format, text)
 		note.CompleteBy = int64(timeValue.Unix())
 		note.UpdatedAt = utils.CurrentUnixTimestamp()

--- a/pkg/utils/functions.go
+++ b/pkg/utils/functions.go
@@ -346,7 +346,7 @@ func GeneratePrompt(promptName string, defaultText string) *promptui.Prompt {
 		}
 	case "note_completed_by":
 		prompt = &promptui.Prompt{
-			Label:    "Due Date (format: YYYY-MM-DD), or enter nil to clear existing value",
+			Label:    "Due Date (format: DD-MM-YYYY), or enter nil to clear existing value",
 			Default:  defaultText,
 			Validate: ValidateDateString,
 		}

--- a/pkg/utils/functions.go
+++ b/pkg/utils/functions.go
@@ -171,11 +171,11 @@ func ValidateNonEmptyString(input string) error {
 	}
 }
 
-// validate date string (YYYY-MM-DD)
+// validate date string (DD-MM-YYYY)
 // nil is also valid input
 func ValidateDateString(input string) error {
 	input = TrimString(input)
-	re := regexp.MustCompile("^(((19|20)\\d\\d)-(0?[1-9]|1[012])-(0?[1-9]|[12][0-9]|3[01])|(nil))$")
+	re := regexp.MustCompile("^((0?[1-9]|[12][0-9]|3[01])-(0?[1-9]|1[012])-((19|20)\\d\\d)|(nil))$")
 	if re.MatchString(input) {
 		return nil
 	} else {

--- a/pkg/utils/functions_test.go
+++ b/pkg/utils/functions_test.go
@@ -137,9 +137,10 @@ func TestValidateNonEmptyString(t *testing.T) {
 }
 
 func TestValidateDateString(t *testing.T) {
-	utils.AssertEqual(t, utils.ValidateDateString("2020-12-31"), nil)
+	utils.AssertEqual(t, utils.ValidateDateString("31-12-2020"), nil)
 	utils.AssertEqual(t, utils.ValidateDateString("nil"), nil)
-	utils.AssertEqual(t, utils.ValidateDateString("2020-31-12"), errors.New("Invalid input"))
+	utils.AssertEqual(t, utils.ValidateDateString("12-31-2020"), errors.New("Invalid input"))
+	utils.AssertEqual(t, utils.ValidateDateString("2020-12-31"), errors.New("Invalid input"))
 	utils.AssertEqual(t, utils.ValidateDateString("2020-31-"), errors.New("Invalid input"))
 	utils.AssertEqual(t, utils.ValidateDateString("2020-31"), errors.New("Invalid input"))
 	utils.AssertEqual(t, utils.ValidateDateString("2020-"), errors.New("Invalid input"))


### PR DESCRIPTION
### Description

Change date format to DD-MM-YYYY

Reason:
- DD-MM part is significant for monthly annual repetition
- DD part is significant for monthly repetition
- DD-MM-YYYY is the default Australian date format

### Tasks

 - [ ] TODO items before it can be reviewed or merged
 - [ ] Another TODO item.

### Risks

- **Low**: May impact "update completed by" functionality.
- Notes for Support:
- Notes for QA:
