### PR TITLE
Make empty tags easy to recognize

### DIFF
--- a/cmd/reminder/main.go
+++ b/cmd/reminder/main.go
@@ -47,8 +47,7 @@ func flow() {
 	switch result {
 	case fmt.Sprintf("%v %v", utils.Symbols["spark"], "List Stuff"):
 		tagSymbol := func(tagSlug string) string {
-			tag := reminderData.TagFromSlug(tagSlug)
-			hasPendingNote := len(reminderData.Notes.WithTagIdAndStatus(tag.Id, "pending")) > 0
+			hasPendingNote := len(reminderData.FindNotesByTagSlug(tagSlug, "pending")) > 0
 			if hasPendingNote {
 				return utils.Symbols["tag"]
 			} else {
@@ -66,7 +65,7 @@ func flow() {
 				_, _ = reminderData.NewTagRegistration()
 			} else {
 				tag := reminderData.Tags[tagIndex]
-				notes := reminderData.FindNotes(tag.Id, "pending")
+				notes := reminderData.FindNotesByTagId(tag.Id, "pending")
 				err := reminderData.PrintNotesAndAskOptions(notes, tag.Id)
 				utils.PrintErrorIfPresent(err)
 			}

--- a/cmd/reminder/main.go
+++ b/cmd/reminder/main.go
@@ -1,3 +1,8 @@
+/*
+Tool `reminder` is a command-line (terminal) based interactive app for organizing tasks with minimal efforts.
+
+Just run it as `go run cmd/reminder/main.go`
+*/
 package main
 
 import (
@@ -41,9 +46,18 @@ func flow() {
 	// operate on main options
 	switch result {
 	case fmt.Sprintf("%v %v", utils.Symbols["spark"], "List Stuff"):
+		tagSymbol := func(tagSlug string) string {
+			tag := reminderData.TagFromSlug(tagSlug)
+			hasPendingNote := len(reminderData.Notes.WithTagIdAndStatus(tag.Id, "pending")) > 0
+			if hasPendingNote {
+				return utils.Symbols["tag"]
+			} else {
+				return utils.Symbols["zzz"]
+			}
+		}
 		var allTagSlugsWithEmoji []string
 		for _, tagSlug := range reminderData.SortedTagSlugs() {
-			allTagSlugsWithEmoji = append(allTagSlugsWithEmoji, fmt.Sprintf("%v %v", utils.Symbols["tag"], tagSlug))
+			allTagSlugsWithEmoji = append(allTagSlugsWithEmoji, fmt.Sprintf("%v %v", tagSymbol(tagSlug), tagSlug))
 		}
 		tagIndex, _ := utils.AskOption(append(allTagSlugsWithEmoji, fmt.Sprintf("%v %v", utils.Symbols["add"], "Add Tag")), "Select Tag")
 		if tagIndex != -1 {

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -582,7 +582,7 @@ func TestNextPossibleTagId(t *testing.T) {
 }
 */
 
-func TestFindNotes(t *testing.T) {
+func TestFindNotesByTagId(t *testing.T) {
 	reminderData := models.ReminderData{
 		User:  &models.User{Name: "Test User", EmailId: "user@test.com"},
 		Notes: []*models.Note{},
@@ -614,13 +614,54 @@ func TestFindNotes(t *testing.T) {
 	reminderData.Notes = notes
 	// searching notes
 	// case 1
-	utils.AssertEqual(t, reminderData.FindNotes(2, "pending"), []*models.Note{&note2})
+	utils.AssertEqual(t, reminderData.FindNotesByTagId(2, "pending"), []*models.Note{&note2})
 	// case 2
-	utils.AssertEqual(t, reminderData.FindNotes(2, "done"), []*models.Note{&note3})
+	utils.AssertEqual(t, reminderData.FindNotesByTagId(2, "done"), []*models.Note{&note3})
 	// case 3
-	utils.AssertEqual(t, reminderData.FindNotes(4, "pending"), []*models.Note{&note1, &note2})
+	utils.AssertEqual(t, reminderData.FindNotesByTagId(4, "pending"), []*models.Note{&note1, &note2})
 	// case 4
-	utils.AssertEqual(t, reminderData.FindNotes(1, "done"), []*models.Note{})
+	utils.AssertEqual(t, reminderData.FindNotesByTagId(1, "done"), []*models.Note{})
+}
+
+func TestFindNotesByTagSlug(t *testing.T) {
+	reminderData := models.ReminderData{
+		User:  &models.User{Name: "Test User", EmailId: "user@test.com"},
+		Notes: []*models.Note{},
+		Tags:  models.Tags{},
+	}
+	// creating tags
+	var tags models.Tags
+	tag1 := models.Tag{Id: 1, Slug: "a", Group: "tag_group1"}
+	tags = append(tags, &tag1)
+	tag2 := models.Tag{Id: 2, Slug: "a1", Group: "tag_group1"}
+	tags = append(tags, &tag2)
+	tag3 := models.Tag{Id: 3, Slug: "a2", Group: "tag_group1"}
+	tags = append(tags, &tag3)
+	tag4 := models.Tag{Id: 4, Slug: "b", Group: "tag_group2"}
+	tags = append(tags, &tag4)
+	reminderData.Tags = tags
+	// create notes
+	var notes models.Notes
+	note1 := models.Note{Text: "1", Status: "pending", TagIds: []int{1, 4}, UpdatedAt: 1600000001}
+	notes = append(notes, &note1)
+	note2 := models.Note{Text: "2", Status: "pending", TagIds: []int{2, 4}, UpdatedAt: 1600000004}
+	notes = append(notes, &note2)
+	note3 := models.Note{Text: "3", Status: "done", TagIds: []int{2}, UpdatedAt: 1600000003}
+	notes = append(notes, &note3)
+	note4 := models.Note{Text: "4", Status: "done", TagIds: []int{}, UpdatedAt: 1600000002}
+	notes = append(notes, &note4)
+	note5 := models.Note{Text: "5", Status: "pending", UpdatedAt: 1600000005}
+	notes = append(notes, &note5)
+	reminderData.Notes = notes
+	// searching notes
+	// case 1
+	utils.AssertEqual(t, reminderData.FindNotesByTagSlug("a1", "pending"), []*models.Note{&note2})
+	// case 2
+	utils.AssertEqual(t, reminderData.FindNotesByTagSlug("a1", "done"), []*models.Note{&note3})
+	// case 3
+	utils.AssertEqual(t, reminderData.FindNotesByTagSlug("b", "pending"), []*models.Note{&note1, &note2})
+	// case 4
+	utils.AssertEqual(t, reminderData.FindNotesByTagSlug("a", "done"), []*models.Note{})
 }
 
 func TestRegisterBasicTags(t *testing.T) {

--- a/internal/models/reminder_data.go
+++ b/internal/models/reminder_data.go
@@ -66,8 +66,14 @@ func (reminderData *ReminderData) TagIdsForGroup(group string) []int {
 }
 
 // get all notes with given tagID and given status
-func (reminderData *ReminderData) FindNotes(tagID int, status string) Notes {
+func (reminderData *ReminderData) FindNotesByTagId(tagID int, status string) Notes {
 	return reminderData.Notes.WithTagIdAndStatus(tagID, status)
+}
+
+// get all notes with given tagSlug and given status
+func (reminderData *ReminderData) FindNotesByTagSlug(tagSlug string, status string) Notes {
+	tag := reminderData.TagFromSlug(tagSlug)
+	return reminderData.FindNotesByTagId(tag.Id, status)
 }
 
 // update note's text

--- a/pkg/utils/bellskipper.go
+++ b/pkg/utils/bellskipper.go
@@ -5,7 +5,8 @@ import (
 )
 
 /*
- * BellSkipper for PromptUI
+ * bellSkipper for PromptUI
+
  * Refer: https://github.com/manifoldco/promptui/issues/49
  * bellSkipper implements an io.WriteCloser that skips the terminal bell
  * character (ASCII code 7), and writes the rest to os.Stderr. It is used to

--- a/pkg/utils/symbols.go
+++ b/pkg/utils/symbols.go
@@ -23,4 +23,5 @@ var Symbols = map[string]string{
 	"pad":          "📋",
 	"add":          "➕",
 	"backup":       "💾",
+	"zzz":          "💤",
 }


### PR DESCRIPTION
### Description

Make empty tags easy to recognize

### Tasks

 - [ ] TODO items before it can be reviewed or merged
 - [ ] Another TODO item.

### Risks

- **Low**: Tag listing might faile.
- Notes for Support:
- Notes for QA:
