### PR TITLE
Move `UpdatedAt` field to `BaseStruct`

### DIFF
--- a/internal/models/base_struct.go
+++ b/internal/models/base_struct.go
@@ -1,0 +1,8 @@
+package models
+
+/*
+BaseStruct represents set of common fields
+*/
+type BaseStruct struct {
+	UpdatedAt int64 `json:"updated_at"`
+}

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -169,10 +169,10 @@ func TestFBasicTags(t *testing.T) {
 
 func TestNotes(t *testing.T) {
 	var notes []*models.Note
-	notes = append(notes, &models.Note{Text: "1", Status: "pending", UpdatedAt: 1600000001})
-	notes = append(notes, &models.Note{Text: "2", Status: "pending", UpdatedAt: 1600000004})
-	notes = append(notes, &models.Note{Text: "3", Status: "done", UpdatedAt: 1600000003})
-	notes = append(notes, &models.Note{Text: "4", Status: "done", UpdatedAt: 1600000002})
+	notes = append(notes, &models.Note{Text: "1", Status: "pending", BaseStruct: models.BaseStruct{UpdatedAt: 1600000001}})
+	notes = append(notes, &models.Note{Text: "2", Status: "pending", BaseStruct: models.BaseStruct{UpdatedAt: 1600000004}})
+	notes = append(notes, &models.Note{Text: "3", Status: "done", BaseStruct: models.BaseStruct{UpdatedAt: 1600000003}})
+	notes = append(notes, &models.Note{Text: "4", Status: "done", BaseStruct: models.BaseStruct{UpdatedAt: 1600000002}})
 	sort.Sort(models.Notes(notes))
 	var gotTexts []string
 	for _, value := range notes {
@@ -297,15 +297,15 @@ func TestWithTagIdAndStatus(t *testing.T) {
 	tags = append(tags, &tag4)
 	// create notes
 	var notes models.Notes
-	note1 := models.Note{Text: "1", Status: "pending", TagIds: []int{1, 4}, UpdatedAt: 1600000001}
+	note1 := models.Note{Text: "1", Status: "pending", TagIds: []int{1, 4}, BaseStruct: models.BaseStruct{UpdatedAt: 1600000001}}
 	notes = append(notes, &note1)
-	note2 := models.Note{Text: "2", Status: "pending", TagIds: []int{2, 4}, UpdatedAt: 1600000004}
+	note2 := models.Note{Text: "2", Status: "pending", TagIds: []int{2, 4}, BaseStruct: models.BaseStruct{UpdatedAt: 1600000004}}
 	notes = append(notes, &note2)
-	note3 := models.Note{Text: "3", Status: "done", TagIds: []int{2}, UpdatedAt: 1600000003}
+	note3 := models.Note{Text: "3", Status: "done", TagIds: []int{2}, BaseStruct: models.BaseStruct{UpdatedAt: 1600000003}}
 	notes = append(notes, &note3)
-	note4 := models.Note{Text: "4", Status: "done", TagIds: []int{}, UpdatedAt: 1600000002}
+	note4 := models.Note{Text: "4", Status: "done", TagIds: []int{}, BaseStruct: models.BaseStruct{UpdatedAt: 1600000002}}
 	notes = append(notes, &note4)
-	note5 := models.Note{Text: "5", Status: "pending", UpdatedAt: 1600000005}
+	note5 := models.Note{Text: "5", Status: "pending", BaseStruct: models.BaseStruct{UpdatedAt: 1600000005}}
 	notes = append(notes, &note5)
 	// searching notes
 	// case 1
@@ -320,7 +320,7 @@ func TestWithTagIdAndStatus(t *testing.T) {
 
 func TestAddComment(t *testing.T) {
 	// create notes
-	note1 := models.Note{Text: "1", Status: "pending", TagIds: []int{1, 4}, UpdatedAt: 1600000001}
+	note1 := models.Note{Text: "1", Status: "pending", TagIds: []int{1, 4}, BaseStruct: models.BaseStruct{UpdatedAt: 1600000001}}
 	// add comments
 	// case 1
 	err := note1.AddComment("test comment 1")
@@ -341,7 +341,7 @@ func TestAddComment(t *testing.T) {
 
 func TestUpdateText(t *testing.T) {
 	// create notes
-	note1 := models.Note{Text: "original text", Status: "pending", TagIds: []int{1, 4}, UpdatedAt: 1600000001}
+	note1 := models.Note{Text: "original text", Status: "pending", TagIds: []int{1, 4}, BaseStruct: models.BaseStruct{UpdatedAt: 1600000001}}
 	// update text
 	// case 1
 	err := note1.UpdateText("updated text 1")
@@ -355,7 +355,7 @@ func TestUpdateText(t *testing.T) {
 
 func TestUpdateCompleteBy(t *testing.T) {
 	// create notes
-	note1 := models.Note{Text: "original text", Status: "pending", TagIds: []int{1, 4}, UpdatedAt: 1600000001}
+	note1 := models.Note{Text: "original text", Status: "pending", TagIds: []int{1, 4}, BaseStruct: models.BaseStruct{UpdatedAt: 1600000001}}
 	utils.AssertEqual(t, note1.CompleteBy, 0)
 	// update complete_by
 	// case 1
@@ -370,7 +370,7 @@ func TestUpdateCompleteBy(t *testing.T) {
 
 func TestUpdateTags(t *testing.T) {
 	// create notes
-	note1 := models.Note{Text: "original text", Status: "pending", TagIds: []int{1, 4}, UpdatedAt: 1600000001}
+	note1 := models.Note{Text: "original text", Status: "pending", TagIds: []int{1, 4}, BaseStruct: models.BaseStruct{UpdatedAt: 1600000001}}
 	// update TagIds
 	// case 1
 	tagIds := []int{2, 5}
@@ -386,7 +386,7 @@ func TestUpdateTags(t *testing.T) {
 
 func TestUpdateStatus(t *testing.T) {
 	// create notes
-	note1 := models.Note{Text: "original text", Status: "pending", TagIds: []int{1, 4}, UpdatedAt: 1600000001}
+	note1 := models.Note{Text: "original text", Status: "pending", TagIds: []int{1, 4}, BaseStruct: models.BaseStruct{UpdatedAt: 1600000001}}
 	// update TagIds
 	// case 1
 	err := note1.UpdateStatus("done", []int{1, 2, 3})
@@ -601,15 +601,15 @@ func TestFindNotesByTagId(t *testing.T) {
 	reminderData.Tags = tags
 	// create notes
 	var notes models.Notes
-	note1 := models.Note{Text: "1", Status: "pending", TagIds: []int{1, 4}, UpdatedAt: 1600000001}
+	note1 := models.Note{Text: "1", Status: "pending", TagIds: []int{1, 4}, BaseStruct: models.BaseStruct{UpdatedAt: 1600000001}}
 	notes = append(notes, &note1)
-	note2 := models.Note{Text: "2", Status: "pending", TagIds: []int{2, 4}, UpdatedAt: 1600000004}
+	note2 := models.Note{Text: "2", Status: "pending", TagIds: []int{2, 4}, BaseStruct: models.BaseStruct{UpdatedAt: 1600000004}}
 	notes = append(notes, &note2)
-	note3 := models.Note{Text: "3", Status: "done", TagIds: []int{2}, UpdatedAt: 1600000003}
+	note3 := models.Note{Text: "3", Status: "done", TagIds: []int{2}, BaseStruct: models.BaseStruct{UpdatedAt: 1600000003}}
 	notes = append(notes, &note3)
-	note4 := models.Note{Text: "4", Status: "done", TagIds: []int{}, UpdatedAt: 1600000002}
+	note4 := models.Note{Text: "4", Status: "done", TagIds: []int{}, BaseStruct: models.BaseStruct{UpdatedAt: 1600000002}}
 	notes = append(notes, &note4)
-	note5 := models.Note{Text: "5", Status: "pending", UpdatedAt: 1600000005}
+	note5 := models.Note{Text: "5", Status: "pending", BaseStruct: models.BaseStruct{UpdatedAt: 1600000005}}
 	notes = append(notes, &note5)
 	reminderData.Notes = notes
 	// searching notes
@@ -642,15 +642,15 @@ func TestFindNotesByTagSlug(t *testing.T) {
 	reminderData.Tags = tags
 	// create notes
 	var notes models.Notes
-	note1 := models.Note{Text: "1", Status: "pending", TagIds: []int{1, 4}, UpdatedAt: 1600000001}
+	note1 := models.Note{Text: "1", Status: "pending", TagIds: []int{1, 4}, BaseStruct: models.BaseStruct{UpdatedAt: 1600000001}}
 	notes = append(notes, &note1)
-	note2 := models.Note{Text: "2", Status: "pending", TagIds: []int{2, 4}, UpdatedAt: 1600000004}
+	note2 := models.Note{Text: "2", Status: "pending", TagIds: []int{2, 4}, BaseStruct: models.BaseStruct{UpdatedAt: 1600000004}}
 	notes = append(notes, &note2)
-	note3 := models.Note{Text: "3", Status: "done", TagIds: []int{2}, UpdatedAt: 1600000003}
+	note3 := models.Note{Text: "3", Status: "done", TagIds: []int{2}, BaseStruct: models.BaseStruct{UpdatedAt: 1600000003}}
 	notes = append(notes, &note3)
-	note4 := models.Note{Text: "4", Status: "done", TagIds: []int{}, UpdatedAt: 1600000002}
+	note4 := models.Note{Text: "4", Status: "done", TagIds: []int{}, BaseStruct: models.BaseStruct{UpdatedAt: 1600000002}}
 	notes = append(notes, &note4)
-	note5 := models.Note{Text: "5", Status: "pending", UpdatedAt: 1600000005}
+	note5 := models.Note{Text: "5", Status: "pending", BaseStruct: models.BaseStruct{UpdatedAt: 1600000005}}
 	notes = append(notes, &note5)
 	reminderData.Notes = notes
 	// searching notes
@@ -717,11 +717,11 @@ func TestFNewNote(t *testing.T) {
 	tagIDs := []int{1, 3, 5}
 	note, _ := models.FNewNote(tagIDs, mockPromptNoteText)
 	want := &models.Note{
-		Text:      "a random note text",
-		TagIds:    tagIDs,
-		Status:    note.Status,
-		CreatedAt: note.CreatedAt,
-		UpdatedAt: note.UpdatedAt,
+		Text:       "a random note text",
+		TagIds:     tagIDs,
+		Status:     note.Status,
+		CreatedAt:  note.CreatedAt,
+		BaseStruct: models.BaseStruct{UpdatedAt: note.UpdatedAt},
 	}
 	utils.AssertEqual(t, note, want)
 }

--- a/internal/models/note.go
+++ b/internal/models/note.go
@@ -19,7 +19,7 @@ type Note struct {
 	TagIds     []int    `json:"tag_ids"`
 	CompleteBy int64    `json:"complete_by"`
 	CreatedAt  int64    `json:"created_at"`
-	UpdatedAt  int64    `json:"updated_at"`
+	BaseStruct
 }
 
 type Notes []*Note
@@ -217,7 +217,7 @@ func FNewNote(tagIDs []int, promptNoteText Prompter) (*Note, error) {
 		CompleteBy: 0,
 		TagIds:     tagIDs,
 		CreatedAt:  utils.CurrentUnixTimestamp(),
-		UpdatedAt:  utils.CurrentUnixTimestamp(),
+		BaseStruct: BaseStruct{UpdatedAt: utils.CurrentUnixTimestamp()},
 		// Text:       noteText,
 	}
 	noteText, err := promptNoteText.Run()

--- a/internal/models/reminder_data.go
+++ b/internal/models/reminder_data.go
@@ -26,7 +26,7 @@ type ReminderData struct {
 	Tags         Tags   `json:"tags"`
 	DataFile     string `json:"data_file"`
 	LastBackupAt int64  `json:"last_backup_at"`
-	UpdatedAt    int64  `json:"updated_at"`
+	BaseStruct
 }
 
 // methods

--- a/internal/models/tag.go
+++ b/internal/models/tag.go
@@ -19,7 +19,7 @@ type Tag struct {
 	Slug      string `json:"slug"`  // client-facing string-based id for tag
 	Group     string `json:"group"` // a note can be part of only one tag within a group
 	CreatedAt int64  `json:"created_at"`
-	UpdatedAt int64  `json:"updated_at"`
+	BaseStruct
 }
 
 // provide basic string representation of a tag
@@ -96,11 +96,11 @@ func FBasicTags() Tags {
 	var basicTags Tags
 	for index, tagMap := range basicTagsMap {
 		tag := Tag{
-			Id:        index,
-			Slug:      tagMap["slug"],
-			Group:     tagMap["group"],
-			CreatedAt: utils.CurrentUnixTimestamp(),
-			UpdatedAt: utils.CurrentUnixTimestamp(),
+			Id:         index,
+			Slug:       tagMap["slug"],
+			Group:      tagMap["group"],
+			CreatedAt:  utils.CurrentUnixTimestamp(),
+			BaseStruct: BaseStruct{UpdatedAt: utils.CurrentUnixTimestamp()},
 		}
 		basicTags = append(basicTags, &tag)
 	}
@@ -110,9 +110,9 @@ func FBasicTags() Tags {
 // prompt for new Tag
 func FNewTag(tagID int, promptTagSlug Prompter, promptTagGroup Prompter) (*Tag, error) {
 	tag := &Tag{
-		Id:        tagID,
-		CreatedAt: utils.CurrentUnixTimestamp(),
-		UpdatedAt: utils.CurrentUnixTimestamp(),
+		Id:         tagID,
+		CreatedAt:  utils.CurrentUnixTimestamp(),
+		BaseStruct: BaseStruct{UpdatedAt: utils.CurrentUnixTimestamp()},
 		// Slug:      tagSlug,
 		// Group:     tagGroup,
 	}


### PR DESCRIPTION
### Description

Move `UpdatedAt` field to `BaseStruct`, and use it via Embedding with anonymous fields.

### Tasks

 - [ ] TODO items before it can be reviewed or merged
 - [ ] Another TODO item.

### Risks

- **Low**: Only impact on `UpdatedAt` field.
- Notes for Support:
- Notes for QA:
