### PR TITLE
Refactor `CreatedAt` field for models

### DIFF
--- a/internal/models/base_struct.go
+++ b/internal/models/base_struct.go
@@ -4,5 +4,6 @@ package models
 BaseStruct represents set of common fields
 */
 type BaseStruct struct {
-	UpdatedAt int64 `json:"updated_at"`
+	UpdatedAt int64 `json:"updated_at,omitempty"`
+	CreatedAt int64 `json:"created_at,omitempty"`
 }

--- a/internal/models/base_struct.go
+++ b/internal/models/base_struct.go
@@ -4,6 +4,6 @@ package models
 BaseStruct represents set of common fields
 */
 type BaseStruct struct {
-	UpdatedAt int64 `json:"updated_at,omitempty"`
 	CreatedAt int64 `json:"created_at,omitempty"`
+	UpdatedAt int64 `json:"updated_at,omitempty"`
 }

--- a/internal/models/comment.go
+++ b/internal/models/comment.go
@@ -13,6 +13,7 @@ A note can have multiple comments
 */
 type Comment struct {
 	Text string `json:"text"`
+	BaseStruct
 }
 
 type Comments []*Comment

--- a/internal/models/comment.go
+++ b/internal/models/comment.go
@@ -12,8 +12,7 @@ A comment belongs to a particular note
 A note can have multiple comments
 */
 type Comment struct {
-	Text      string `json:"text"`
-	CreatedAt int64  `json:"created_at"`
+	Text string `json:"text"`
 }
 
 type Comments []*Comment

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -720,8 +720,7 @@ func TestFNewNote(t *testing.T) {
 		Text:       "a random note text",
 		TagIds:     tagIDs,
 		Status:     note.Status,
-		CreatedAt:  note.CreatedAt,
-		BaseStruct: models.BaseStruct{UpdatedAt: note.UpdatedAt},
+		BaseStruct: models.BaseStruct{UpdatedAt: note.UpdatedAt, CreatedAt: note.CreatedAt},
 	}
 	utils.AssertEqual(t, note, want)
 }

--- a/internal/models/note.go
+++ b/internal/models/note.go
@@ -18,7 +18,6 @@ type Note struct {
 	Status     string   `json:"status"`
 	TagIds     []int    `json:"tag_ids"`
 	CompleteBy int64    `json:"complete_by"`
-	CreatedAt  int64    `json:"created_at"`
 	BaseStruct
 }
 

--- a/internal/models/note.go
+++ b/internal/models/note.go
@@ -82,7 +82,7 @@ func (note *Note) AddComment(text string) error {
 		fmt.Printf("%v Skipping adding comment with empty text\n", utils.Symbols["warning"])
 		return errors.New("Note's comment text is empty")
 	} else {
-		comment := &Comment{Text: text, CreatedAt: utils.CurrentUnixTimestamp()}
+		comment := &Comment{Text: text, BaseStruct: BaseStruct{CreatedAt: utils.CurrentUnixTimestamp()}}
 		note.Comments = append(note.Comments, comment)
 		note.UpdatedAt = utils.CurrentUnixTimestamp()
 		fmt.Println("Updated the note")
@@ -215,8 +215,9 @@ func FNewNote(tagIDs []int, promptNoteText Prompter) (*Note, error) {
 		Status:     "pending",
 		CompleteBy: 0,
 		TagIds:     tagIDs,
-		CreatedAt:  utils.CurrentUnixTimestamp(),
-		BaseStruct: BaseStruct{UpdatedAt: utils.CurrentUnixTimestamp()},
+		BaseStruct: BaseStruct{
+			CreatedAt: utils.CurrentUnixTimestamp(),
+			UpdatedAt: utils.CurrentUnixTimestamp()},
 		// Text:       noteText,
 	}
 	noteText, err := promptNoteText.Run()

--- a/internal/models/tag.go
+++ b/internal/models/tag.go
@@ -95,11 +95,12 @@ func FBasicTags() Tags {
 	var basicTags Tags
 	for index, tagMap := range basicTagsMap {
 		tag := Tag{
-			Id:         index,
-			Slug:       tagMap["slug"],
-			Group:      tagMap["group"],
-			CreatedAt:  utils.CurrentUnixTimestamp(),
-			BaseStruct: BaseStruct{UpdatedAt: utils.CurrentUnixTimestamp()},
+			Id:    index,
+			Slug:  tagMap["slug"],
+			Group: tagMap["group"],
+			BaseStruct: BaseStruct{
+				CreatedAt: utils.CurrentUnixTimestamp(),
+				UpdatedAt: utils.CurrentUnixTimestamp()},
 		}
 		basicTags = append(basicTags, &tag)
 	}
@@ -109,9 +110,10 @@ func FBasicTags() Tags {
 // prompt for new Tag
 func FNewTag(tagID int, promptTagSlug Prompter, promptTagGroup Prompter) (*Tag, error) {
 	tag := &Tag{
-		Id:         tagID,
-		CreatedAt:  utils.CurrentUnixTimestamp(),
-		BaseStruct: BaseStruct{UpdatedAt: utils.CurrentUnixTimestamp()},
+		Id: tagID,
+		BaseStruct: BaseStruct{
+			CreatedAt: utils.CurrentUnixTimestamp(),
+			UpdatedAt: utils.CurrentUnixTimestamp()},
 		// Slug:      tagSlug,
 		// Group:     tagGroup,
 	}

--- a/internal/models/tag.go
+++ b/internal/models/tag.go
@@ -15,10 +15,9 @@ A note can have multiple tags
 A tag can be associated with multiple notes
 */
 type Tag struct {
-	Id        int    `json:"id"`    // internal int-based id of the tag
-	Slug      string `json:"slug"`  // client-facing string-based id for tag
-	Group     string `json:"group"` // a note can be part of only one tag within a group
-	CreatedAt int64  `json:"created_at"`
+	Id    int    `json:"id"`    // internal int-based id of the tag
+	Slug  string `json:"slug"`  // client-facing string-based id for tag
+	Group string `json:"group"` // a note can be part of only one tag within a group
 	BaseStruct
 }
 


### PR DESCRIPTION
### Description

Refactor `CreatedAt` field for models

### Tasks

 - [ ] TODO items before it can be reviewed or merged
 - [ ] Another TODO item.

### Risks

- **Low**: Impacts only `CreatedAt` field
- Notes for Support:
- Notes for QA:
