### PR TITLE
Remove redundant "Add Note" and "Add Tag" options

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Also note that you can choose an option by pressing **Enter** key, and use **Ctr
 
 In [`reminder`](https://github.com/goyalmunish/reminder), the **tags** are the main method of categorizing tasks. When you first time start the app, the tag list is empty, but you can use the **"Register Basic Tags"** option (the option pointed out by the selection-cursor in the above figure) to register basic tags (as listed in the figure below). Then, you can use the **"List Stuff"** option to list them out (as shown below figure).
 
-As we'll see, the **"List Stuff"** option is the most frequently used option in this list. It lets you add tags, add tasks (also referred to as "notes") under those tags, update those tasks; so almost 90% of use-cases. The **Main Menu** also lists options such as **"Add Note"** and **"Add Tag"** at the root level of this menu, but you'll rarely have to use them directly, as these functionalities can be handled from within the **"List Stuff"** option in a convenient two-level tree-based hierarchy of tags and tasks.
+As we'll see, the **"List Stuff"** option is the most frequently used option in this list. It lets you add tags, add tasks (also referred to as "notes") under those tags, update those tasks; so almost 90% of use-cases.
 
 <p align="center">
   <img src="./assets/images/screen_basic_tags_02.png" width="100%">

--- a/cmd/reminder/main.go
+++ b/cmd/reminder/main.go
@@ -39,26 +39,19 @@ func flow() {
 		But, if you are inside PromptUI's `Run()`, then it cancels the input and moves to next
 		statement in the code.
 	*/
-	_, result, _ := utils.AskOption([]string{fmt.Sprintf("%v %v", utils.Symbols["spark"], "List Stuff"),
+	_, result, _ := utils.AskOption([]string{
+		fmt.Sprintf("%v %v", utils.Symbols["spark"], "List Stuff"),
 		fmt.Sprintf("%v %v %v", utils.Symbols["checkerdFlag"], "Exit", utils.Symbols["redFlag"]),
 		fmt.Sprintf("%v %v", utils.Symbols["clock"], "Urgent Notes"),
 		fmt.Sprintf("%v %v", utils.Symbols["done"], "Done Notes"),
 		fmt.Sprintf("%v %v", utils.Symbols["search"], "Search Notes"),
-		fmt.Sprintf("%v %v", utils.Symbols["clip"], "Add Note"),
-		fmt.Sprintf("%v %v", utils.Symbols["clip"], "Add Tag"),
 		fmt.Sprintf("%v %v", utils.Symbols["clip"], "Register Basic Tags"),
 		fmt.Sprintf("%v %v", utils.Symbols["backup"], "Create Backup"),
 		fmt.Sprintf("%v %v", utils.Symbols["pad"], "Display Data File")}, "Select Option")
 	// operate on main options
 	switch result {
 	case fmt.Sprintf("%v %v", utils.Symbols["spark"], "List Stuff"):
-		err := reminderData.ListTags()
-		utils.PrintErrorIfPresent(err)
-	case fmt.Sprintf("%v %v", utils.Symbols["clip"], "Add Note"):
-		tagIDs := reminderData.AskTagIds([]int{})
-		_, _ = reminderData.NewNoteRegistration(tagIDs)
-	case fmt.Sprintf("%v %v", utils.Symbols["clip"], "Add Tag"):
-		_, _ = reminderData.NewTagRegistration()
+		_ = reminderData.ListTags()
 	case fmt.Sprintf("%v %v", utils.Symbols["clip"], "Register Basic Tags"):
 		reminderData.RegisterBasicTags()
 	case fmt.Sprintf("%v %v", utils.Symbols["clock"], "Urgent Notes"):

--- a/cmd/reminder/main.go
+++ b/cmd/reminder/main.go
@@ -39,7 +39,7 @@ func flow() {
 		But, if you are inside PromptUI's `Run()`, then it cancels the input and moves to next
 		statement in the code.
 	*/
-	_, result := utils.AskOption([]string{fmt.Sprintf("%v %v", utils.Symbols["spark"], "List Stuff"),
+	_, result, _ := utils.AskOption([]string{fmt.Sprintf("%v %v", utils.Symbols["spark"], "List Stuff"),
 		fmt.Sprintf("%v %v %v", utils.Symbols["checkerdFlag"], "Exit", utils.Symbols["redFlag"]),
 		fmt.Sprintf("%v %v", utils.Symbols["clock"], "Urgent Notes"),
 		fmt.Sprintf("%v %v", utils.Symbols["done"], "Done Notes"),

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -86,6 +86,9 @@ func TestTags(t *testing.T) {
 func TestSlugs(t *testing.T) {
 	var tags models.Tags
 	utils.AssertEqual(t, tags, "[]")
+	// case 1 (no tags)
+	utils.AssertEqual(t, tags.Slugs(), "[]")
+	// case 2 (non-empty tags)
 	tags = append(tags, &models.Tag{Id: 1, Slug: "tag_1", Group: "tag_group"})
 	tags = append(tags, &models.Tag{Id: 2, Slug: "tag_2", Group: "tag_group"})
 	tags = append(tags, &models.Tag{Id: 3, Slug: "tag_3", Group: "tag_group"})
@@ -105,17 +108,17 @@ func TestFromSlug(t *testing.T) {
 	tags = append(tags, &tag3)
 	tag4 := models.Tag{Id: 4, Slug: "b", Group: "tag_group2"}
 	tags = append(tags, &tag4)
-	// case 1
+	// case 1 (passing non-existing slug)
+	utils.AssertEqual(t, tags.FromSlug("no_such_slug"), nil)
+	// case 2 (passing tag which is part of another tag as well)
 	utils.AssertEqual(t, tags.FromSlug("a"), &tag1)
-	// case 2
-	utils.AssertEqual(t, tags.FromSlug("a1"), &tag2)
 	// case 3
-	utils.AssertEqual(t, tags.FromSlug("no_slug"), nil)
+	utils.AssertEqual(t, tags.FromSlug("a1"), &tag2)
 }
 
 func TestFromIds(t *testing.T) {
-	// creating tags
 	var tags models.Tags
+	// creating tags
 	tag1 := models.Tag{Id: 1, Slug: "a", Group: "tag_group1"}
 	tags = append(tags, &tag1)
 	tag2 := models.Tag{Id: 2, Slug: "z", Group: "tag_group1"}
@@ -124,17 +127,22 @@ func TestFromIds(t *testing.T) {
 	tags = append(tags, &tag3)
 	tag4 := models.Tag{Id: 4, Slug: "b", Group: "tag_group2"}
 	tags = append(tags, &tag4)
-	// case 1
-	tagIDs := []int{1, 3}
+	// case 1 (passing blank tagIDs)
+	tagIDs := []int{}
 	gotSlugs := tags.FromIds(tagIDs)
-	wantSlugs := models.Tags{&tag1, &tag3}
+	wantSlugs := models.Tags{}
 	utils.AssertEqual(t, gotSlugs, wantSlugs)
-	// case 2
-	tagIDs = []int{}
+	// case 2 (no matching tagIDs)
+	tagIDs = []int{100, 101}
 	gotSlugs = tags.FromIds(tagIDs)
 	wantSlugs = models.Tags{}
 	utils.AssertEqual(t, gotSlugs, wantSlugs)
-	// case 3
+	// case 3 (two matching tagIDs)
+	tagIDs = []int{1, 3}
+	gotSlugs = tags.FromIds(tagIDs)
+	wantSlugs = models.Tags{&tag1, &tag3}
+	utils.AssertEqual(t, gotSlugs, wantSlugs)
+	// case 4
 	tagIDs = []int{1, 4, 2, 3}
 	gotSlugs = tags.FromIds(tagIDs)
 	wantSlugs = models.Tags{&tag1, &tag4, &tag2, &tag3}
@@ -152,12 +160,12 @@ func TestIdsForGroup(t *testing.T) {
 	tags = append(tags, &tag3)
 	tag4 := models.Tag{Id: 4, Slug: "b", Group: "tag_group2"}
 	tags = append(tags, &tag4)
-	// case 1
-	utils.AssertEqual(t, tags.IdsForGroup("tag_group1"), []int{1, 2, 3})
-	// case 2
-	utils.AssertEqual(t, tags.IdsForGroup("tag_group2"), []int{4})
-	// case 3
+	// case 1 (group with no such name)
 	utils.AssertEqual(t, tags.IdsForGroup("tag_group_NO"), []int{})
+	// case 1 (group with multiple tags)
+	utils.AssertEqual(t, tags.IdsForGroup("tag_group1"), []int{1, 2, 3})
+	// case 2 (group with single tag)
+	utils.AssertEqual(t, tags.IdsForGroup("tag_group2"), []int{4})
 }
 
 func TestFBasicTags(t *testing.T) {
@@ -469,6 +477,9 @@ func TestSortedTagsSlug(t *testing.T) {
 	}
 	// creating tags
 	var tags models.Tags
+	// case 1 (no tags)
+	utils.AssertEqual(t, reminderData.SortedTagSlugs(), []string{})
+	// case 2 (has couple of tags)
 	tags = append(tags, &models.Tag{Id: 1, Slug: "a", Group: "tag_group1"})
 	tags = append(tags, &models.Tag{Id: 2, Slug: "z", Group: "tag_group1"})
 	tags = append(tags, &models.Tag{Id: 3, Slug: "c", Group: "tag_group1"})

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -252,23 +252,26 @@ func TestSearchableText(t *testing.T) {
 
 func TestExternalTexts(t *testing.T) {
 	var notes models.Notes
+	// case 1 (no notes)
+	utils.AssertEqual(t, "[]", "[]")
+	// add notes
 	comments := models.Comments{&models.Comment{Text: "c1"}}
 	notes = append(notes, &models.Note{Text: "beautiful little cat", Comments: comments, Status: "pending", TagIds: []int{1, 2}, CompleteBy: 1609669231})
 	comments = models.Comments{&models.Comment{Text: "c1"}, &models.Comment{Text: "foo bar"}, &models.Comment{Text: "c3"}, &models.Comment{Text: "baz"}}
 	notes = append(notes, &models.Note{Text: "cute brown dog", Comments: comments, Status: "done", TagIds: []int{1, 2}, CompleteBy: 1609669232})
-	// case 1
+	// case 2
 	got := notes.ExternalTexts(0)
 	want := "[beautiful little cat {C:01, S:P, D:03-Jan-21} cute brown dog {C:04, S:D, D:03-Jan-21}]"
 	utils.AssertEqual(t, got, want)
-	// case 2
+	// case 3
 	got = notes.ExternalTexts(5)
 	want = "[be... {C:01, S:P, D:03-Jan-21} cu... {C:04, S:D, D:03-Jan-21}]"
 	utils.AssertEqual(t, got, want)
-	// case 3
+	// case 4
 	got = notes.ExternalTexts(15)
 	want = "[beautiful li... {C:01, S:P, D:03-Jan-21} cute brown dog  {C:04, S:D, D:03-Jan-21}]"
 	utils.AssertEqual(t, got, want)
-	// case 4
+	// case 5
 	got = notes.ExternalTexts(25)
 	want = "[beautiful little cat      {C:01, S:P, D:03-Jan-21} cute brown dog            {C:04, S:D, D:03-Jan-21}]"
 	utils.AssertEqual(t, got, want)
@@ -276,6 +279,9 @@ func TestExternalTexts(t *testing.T) {
 
 func TestWithStatus(t *testing.T) {
 	var notes models.Notes
+	// case 1 (no notes)
+	utils.AssertEqual(t, notes.WithStatus("pending"), models.Notes{})
+	// add some notes
 	comments := models.Comments{&models.Comment{Text: "c1"}}
 	note1 := models.Note{Text: "big fat cat", Comments: comments, Status: "pending", TagIds: []int{1, 2}, CompleteBy: 1609669231}
 	notes = append(notes, &note1)
@@ -285,19 +291,24 @@ func TestWithStatus(t *testing.T) {
 	comments = models.Comments{&models.Comment{Text: "foo bar"}, &models.Comment{Text: "c3"}}
 	note3 := models.Note{Text: "little hamster", Comments: comments, Status: "pending", TagIds: []int{1}, CompleteBy: 1609669233}
 	notes = append(notes, &note3)
-	// case 1
+	// case 2 (with an invalid status)
+	utils.AssertEqual(t, notes.WithStatus("no-such-status"), models.Notes{})
+	// case 3 (with valid status "pending")
 	got := notes.WithStatus("pending")
-	want := []*models.Note{&note1, &note3}
+	want := models.Notes{&note1, &note3}
 	utils.AssertEqual(t, got, want)
-	// case 2
+	// case 4 (with valid status "done")
 	got = notes.WithStatus("done")
-	want = []*models.Note{&note2}
+	want = models.Notes{&note2}
 	utils.AssertEqual(t, got, want)
 }
 
 func TestWithTagIdAndStatus(t *testing.T) {
-	// creating tags
 	var tags models.Tags
+	var notes models.Notes
+	// case 1 (no notes)
+	utils.AssertEqual(t, notes.WithTagIdAndStatus(2, "pending"), models.Notes{})
+	// creating tags
 	tag1 := models.Tag{Id: 1, Slug: "a", Group: "tag_group1"}
 	tags = append(tags, &tag1)
 	tag2 := models.Tag{Id: 2, Slug: "a1", Group: "tag_group1"}
@@ -307,7 +318,6 @@ func TestWithTagIdAndStatus(t *testing.T) {
 	tag4 := models.Tag{Id: 4, Slug: "b", Group: "tag_group2"}
 	tags = append(tags, &tag4)
 	// create notes
-	var notes models.Notes
 	note1 := models.Note{Text: "1", Status: "pending", TagIds: []int{1, 4}, BaseStruct: models.BaseStruct{UpdatedAt: 1600000001}}
 	notes = append(notes, &note1)
 	note2 := models.Note{Text: "2", Status: "pending", TagIds: []int{2, 4}, BaseStruct: models.BaseStruct{UpdatedAt: 1600000004}}
@@ -318,14 +328,13 @@ func TestWithTagIdAndStatus(t *testing.T) {
 	notes = append(notes, &note4)
 	note5 := models.Note{Text: "5", Status: "pending", BaseStruct: models.BaseStruct{UpdatedAt: 1600000005}}
 	notes = append(notes, &note5)
-	// searching notes
-	// case 1
-	utils.AssertEqual(t, notes.WithTagIdAndStatus(2, "pending"), []*models.Note{&note2})
 	// case 2
-	utils.AssertEqual(t, notes.WithTagIdAndStatus(2, "done"), []*models.Note{&note3})
+	utils.AssertEqual(t, notes.WithTagIdAndStatus(2, "pending"), []*models.Note{&note2})
 	// case 3
-	utils.AssertEqual(t, notes.WithTagIdAndStatus(4, "pending"), []*models.Note{&note1, &note2})
+	utils.AssertEqual(t, notes.WithTagIdAndStatus(2, "done"), []*models.Note{&note3})
 	// case 4
+	utils.AssertEqual(t, notes.WithTagIdAndStatus(4, "pending"), []*models.Note{&note1, &note2})
+	// case 5
 	utils.AssertEqual(t, notes.WithTagIdAndStatus(1, "done"), []*models.Note{})
 }
 

--- a/internal/models/note.go
+++ b/internal/models/note.go
@@ -148,8 +148,9 @@ func (note *Note) UpdateStatus(status string, repeatTagIDs []int) error {
 	return nil
 }
 
-// get display text of list of notes
-// width of each note is truncated to maxStrLen
+// get display text (that is, external representation) of list of notes
+// with width of each note is truncated to maxStrLen
+// return empty []string if there are no notes
 func (notes Notes) ExternalTexts(maxStrLen int) []string {
 	// assuming there are at least (on average) 100s of notes
 	allTexts := make([]string, 0, 100)
@@ -167,6 +168,7 @@ func (notes Notes) ExternalTexts(maxStrLen int) []string {
 }
 
 // filter notes with given status (such as "pending" status)
+// return empty Notes if no matching Note is found (even when given status doesn't exist)
 func (notes Notes) WithStatus(status string) Notes {
 	var result Notes
 	for _, note := range notes {
@@ -178,6 +180,7 @@ func (notes Notes) WithStatus(status string) Notes {
 }
 
 // get all notes with given tagID and given status
+// return empty Notes if no matching Note is found (even when given tagID or status doesn't exist)
 func (notes Notes) WithTagIdAndStatus(tagID int, status string) Notes {
 	notesWithStatus := notes.WithStatus(status)
 	var result Notes

--- a/internal/models/reminder_data.go
+++ b/internal/models/reminder_data.go
@@ -154,7 +154,7 @@ func (reminderData *ReminderData) RegisterBasicTags() {
 	}
 }
 
-// list all tags (and their notes underneath)
+// prompt a list all tags (and their notes underneath)
 func (reminderData *ReminderData) ListTags() error {
 	// function to return a tag sumbol
 	// keep different tag symbol for empty tags
@@ -173,22 +173,24 @@ func (reminderData *ReminderData) ListTags() error {
 		allTagSlugsWithEmoji = append(allTagSlugsWithEmoji, fmt.Sprintf("%v %v", tagSymbol(tagSlug), tagSlug))
 	}
 	// ask user to select a tag
-	tagIndex, _, _ := utils.AskOption(append(allTagSlugsWithEmoji, fmt.Sprintf("%v %v", utils.Symbols["add"], "Add Tag")), "Select Tag")
-	if tagIndex == -1 {
+	tagIndex, _, err := utils.AskOption(append(allTagSlugsWithEmoji, fmt.Sprintf("%v %v", utils.Symbols["add"], "Add Tag")), "Select Tag")
+	if (err != nil) || (tagIndex == -1) {
 		// do nothing, just exit
-		return nil
+		return err
 	}
+	// check if user wants to add a new tag
 	if tagIndex == len(reminderData.SortedTagSlugs()) {
 		// add new tag
 		_, _ = reminderData.NewTagRegistration()
-	} else {
-		tag := reminderData.Tags[tagIndex]
-		err := reminderData.PrintNotesAndAskOptions(Notes{}, tag.Id, "pending")
-		if err != nil {
-			utils.PrintErrorIfPresent(err)
-			// go back to ListTags
-			reminderData.ListTags()
-		}
+		return nil
+	}
+	// operate on the selected a tag
+	tag := reminderData.Tags[tagIndex]
+	err = reminderData.PrintNotesAndAskOptions(Notes{}, tag.Id, "pending")
+	if err != nil {
+		utils.PrintErrorIfPresent(err)
+		// go back to ListTags
+		reminderData.ListTags()
 	}
 	return nil
 }
@@ -459,9 +461,12 @@ func (reminderData *ReminderData) AskTagIds(tagIDs []int) []int {
 }
 
 // method to print note and display options
+// like utils.AskOptions, it prints any encountered error, but doesn't returns that error just for information
+// it return string representing workflow direction
 func (reminderData *ReminderData) PrintNoteAndAskOptions(note *Note) string {
 	fmt.Print(note.ExternalText(reminderData))
-	_, noteOption, _ := utils.AskOption([]string{fmt.Sprintf("%v %v", utils.Symbols["comment"], "Add comment"),
+	_, noteOption, _ := utils.AskOption([]string{
+		fmt.Sprintf("%v %v", utils.Symbols["comment"], "Add comment"),
 		fmt.Sprintf("%v %v", utils.Symbols["home"], "Exit to main menu"),
 		fmt.Sprintf("%v %v", utils.Symbols["noAction"], "Do nothing"),
 		fmt.Sprintf("%v %v", utils.Symbols["upVote"], "Mark as done"),
@@ -470,7 +475,6 @@ func (reminderData *ReminderData) PrintNoteAndAskOptions(note *Note) string {
 		fmt.Sprintf("%v %v", utils.Symbols["tag"], "Update tags"),
 		fmt.Sprintf("%v %v", utils.Symbols["text"], "Update text")},
 		"Select Action")
-	fmt.Println("Do you want to update the note?")
 	switch noteOption {
 	case fmt.Sprintf("%v %v", utils.Symbols["comment"], "Add comment"):
 		promptCommment := utils.GeneratePrompt("note_comment", "")
@@ -514,8 +518,9 @@ func (reminderData *ReminderData) PrintNoteAndAskOptions(note *Note) string {
 }
 
 // method (recursively) to print notes interactively
-// in some cases, notes will be fetched, so blank notes can be passed
+// in some cases, updated list notes will be fetched, so blank notes can be passed in those cases
 // unless notes are to be fetched, the passed `status` doesn't make sense, so in such cases it can be passed as "fake"
+// like utils.AskOptions, it prints any encountered error, and returns that error just for information
 func (reminderData *ReminderData) PrintNotesAndAskOptions(notes Notes, tagID int, status string) error {
 	// check if passed notes is to be used or to fetch latest notes
 	if status == "done" {
@@ -548,11 +553,12 @@ func (reminderData *ReminderData) PrintNotesAndAskOptions(notes Notes, tagID int
 	} else {
 		promptText = fmt.Sprintf("Select Note")
 	}
-	noteIndex, _, _ := utils.AskOption(append(texts, fmt.Sprintf("%v %v", utils.Symbols["add"], "Add Note")), promptText)
-	if noteIndex == -1 {
-		return errors.New("The noteIndex is invalid!")
+	// ask user to select a note
+	noteIndex, _, err := utils.AskOption(append(texts, fmt.Sprintf("%v %v", utils.Symbols["add"], "Add Note")), promptText)
+	if (err != nil) || (noteIndex == -1) {
+		return err
 	}
-	// create new note or show note options
+	// create new note
 	if noteIndex == len(texts) {
 		// add new note
 		if tagID < 0 {
@@ -567,14 +573,14 @@ func (reminderData *ReminderData) PrintNotesAndAskOptions(notes Notes, tagID int
 		updatedNotes = append(updatedNotes, note)
 		updatedNotes = append(updatedNotes, notes...)
 		reminderData.PrintNotesAndAskOptions(updatedNotes, tagID, status)
-	} else {
-		// ask options about select note
-		note := notes[noteIndex]
-		action := reminderData.PrintNoteAndAskOptions(note)
-		if action == "stay" {
-			// no action was selected for the note, go one step back
-			reminderData.PrintNotesAndAskOptions(notes, tagID, status)
-		}
+		return nil
+	}
+	// ask options about the selected note
+	note := notes[noteIndex]
+	action := reminderData.PrintNoteAndAskOptions(note)
+	if action == "stay" {
+		// no action was selected for the note, go one step back
+		reminderData.PrintNotesAndAskOptions(notes, tagID, status)
 	}
 	return nil
 }

--- a/internal/models/tag.go
+++ b/internal/models/tag.go
@@ -55,6 +55,7 @@ func (tags Tags) FromSlug(slug string) *Tag {
 }
 
 // get tags from tagIDs
+// return empty Tags if non of tagIDs match
 func (tags Tags) FromIds(tagIDs []int) Tags {
 	var filteredTags Tags
 	for _, tagID := range tagIDs {
@@ -68,6 +69,7 @@ func (tags Tags) FromIds(tagIDs []int) Tags {
 }
 
 // get tag ids of given group
+// return empty []int if group with given group name doesn't exist
 func (tags Tags) IdsForGroup(group string) []int {
 	var tagIDs []int
 	for _, tag := range tags {

--- a/pkg/utils/functions.go
+++ b/pkg/utils/functions.go
@@ -213,10 +213,13 @@ func IsTimeForRepeatNote(noteTimestampCurrent, noteTimestampPrevious, noteTimest
 }
 
 // ask option to the user
-func AskOption(options []string, label string) (int, string) {
+// print error, if encountered any (so that they don't have to printed by calling function)
+// return a tuple (chosen_index, chosen_string, error_if_any)
+func AskOption(options []string, label string) (int, string, error) {
 	if len(options) == 0 {
-		fmt.Println("No results")
-		return -1, "error"
+		err := errors.New("Empty List")
+		fmt.Printf("%v Prompt failed %v\n", Symbols["warning"], err)
+		return -1, "", err
 	}
 	// note: any item in options should not have \n character
 	// otherwise such item is observed to not getting appear
@@ -229,11 +232,12 @@ func AskOption(options []string, label string) (int, string) {
 	}
 	index, result, err := prompt.Run()
 	if err != nil {
+		// error can happen if user raises an interrupt (such as Ctrl-c, SIGINT)
 		fmt.Printf("%v Prompt failed %v\n", Symbols["warning"], err)
-		return -1, "error"
+		return -1, "", err
 	}
 	fmt.Printf("You chose %d:%q\n", index, result)
-	return index, result
+	return index, result, nil
 }
 
 // perform shell operation and return its output


### PR DESCRIPTION
### Description

Remove redundant "Add Note" and "Add Tag" options

### Tasks

 - [ ] TODO items before it can be reviewed or merged
 - [ ] Another TODO item.

### Risks

- **Low**: Removing redundant options
- Notes for Support:
- Notes for QA:
