### PR TITLE
Use local time as the default

### DIFF
--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -191,6 +191,7 @@ func TestNotes(t *testing.T) {
 }
 
 func TestNoteStrings(t *testing.T) {
+	utils.Location = utils.UTCLocation()
 	comments := models.Comments{&models.Comment{Text: "c1"}, &models.Comment{Text: "c2"}, &models.Comment{Text: "c3"}}
 	note := &models.Note{Text: "dummy text", Comments: comments, Status: "pending", TagIds: []int{1, 2}, CompleteBy: 1609669235}
 	want := `[  |          Text:  dummy text
@@ -208,6 +209,7 @@ func TestNoteStrings(t *testing.T) {
 }
 
 func TestExternalText(t *testing.T) {
+	utils.Location = utils.UTCLocation()
 	comments := models.Comments{&models.Comment{Text: "c1"}, &models.Comment{Text: "c2"}, &models.Comment{Text: "c3"}}
 	note := &models.Note{Text: "dummy text", Comments: comments, Status: "pending", TagIds: []int{1, 2}, CompleteBy: 1609669235}
 	var tags models.Tags

--- a/pkg/utils/functions.go
+++ b/pkg/utils/functions.go
@@ -18,11 +18,13 @@ import (
 	"github.com/manifoldco/promptui"
 )
 
+// location info for `time`
+// it can be set to update behavior of UnixTimestampToTime
+var Location *time.Location
+
 // get current time
-// serve as a central place to switch between
-// local time and UTC
 func CurrentTime() time.Time {
-	return time.Now().UTC()
+	return time.Now()
 }
 
 // get current unix timestamp
@@ -30,9 +32,21 @@ func CurrentUnixTimestamp() int64 {
 	return int64(CurrentTime().Unix())
 }
 
+// return UTC location
+func UTCLocation() *time.Location {
+	location, _ := time.LoadLocation("UTC")
+	return location
+}
+
 // convert unix timestamp to time
+// serve as central place to switch between UTC and local time
+// by default use local time, but behavior can be changed via `Location`
 func UnixTimestampToTime(unixTimestamp int64) time.Time {
-	return time.Unix(unixTimestamp, 0).UTC()
+	t := time.Unix(unixTimestamp, 0)
+	if Location == nil {
+		return t
+	}
+	return t.In(Location)
 }
 
 // convert unix timestamp to time string
@@ -51,14 +65,14 @@ func UnixTimestampToLongTimeStr(unixTimestamp int64) string {
 	return UnixTimestampToTimeStr(unixTimestamp, time.RFC850)
 }
 
-// convert unix timestamp to short time string
-func UnixTimestampToShortTimeStr(unixTimestamp int64) string {
-	return UnixTimestampToTimeStr(unixTimestamp, "02-Jan-06")
-}
-
 // convert unix timestamp to medium time string
 func UnixTimestampToMediumTimeStr(unixTimestamp int64) string {
 	return UnixTimestampToTimeStr(unixTimestamp, "02-Jan-06 15:04:05")
+}
+
+// convert unix timestamp to short time string
+func UnixTimestampToShortTimeStr(unixTimestamp int64) string {
+	return UnixTimestampToTimeStr(unixTimestamp, "02-Jan-06")
 }
 
 // get unix timestamp for date corresponding to current year

--- a/pkg/utils/functions_test.go
+++ b/pkg/utils/functions_test.go
@@ -38,6 +38,7 @@ func TestUnixTimestampToTime(t *testing.T) {
 }
 
 func TestUnixTimestampToTimeStr(t *testing.T) {
+	utils.Location = utils.UTCLocation()
 	output := utils.UnixTimestampToTimeStr(int64(1608575176), "02-Jan-06")
 	utils.AssertEqual(t, output, "21-Dec-20")
 	output = utils.UnixTimestampToTimeStr(int64(1608575176), time.RFC850)
@@ -46,22 +47,26 @@ func TestUnixTimestampToTimeStr(t *testing.T) {
 	utils.AssertEqual(t, output, "nil")
 }
 
-func TestUnixTimestampToShortTimeStr(t *testing.T) {
-	output := utils.UnixTimestampToShortTimeStr(int64(1608575176))
-	utils.AssertEqual(t, output, "21-Dec-20")
-}
-
-func TestUnixTimestampToMediumTimeStr(t *testing.T) {
-	output := utils.UnixTimestampToMediumTimeStr(int64(1608575176))
-	utils.AssertEqual(t, output, "21-Dec-20 18:26:16")
-}
-
 func TestUnixTimestampToLongTimeStr(t *testing.T) {
+	utils.Location = utils.UTCLocation()
 	output := utils.UnixTimestampToLongTimeStr(int64(1608575176))
 	utils.AssertEqual(t, output, "Monday, 21-Dec-20 18:26:16 UTC")
 }
 
+func TestUnixTimestampToMediumTimeStr(t *testing.T) {
+	utils.Location = utils.UTCLocation()
+	output := utils.UnixTimestampToMediumTimeStr(int64(1608575176))
+	utils.AssertEqual(t, output, "21-Dec-20 18:26:16")
+}
+
+func TestUnixTimestampToShortTimeStr(t *testing.T) {
+	utils.Location = utils.UTCLocation()
+	output := utils.UnixTimestampToShortTimeStr(int64(1608575176))
+	utils.AssertEqual(t, output, "21-Dec-20")
+}
+
 func TestUnixTimestampForCorrespondingCurrentYear(t *testing.T) {
+	utils.Location = utils.UTCLocation()
 	got := utils.UnixTimestampForCorrespondingCurrentYear(9, 30) - utils.UnixTimestampForCorrespondingCurrentYear(6, 30)
 	utils.AssertEqual(t, got, 7948800)
 	got = utils.UnixTimestampForCorrespondingCurrentYear(10, 1) - utils.UnixTimestampForCorrespondingCurrentYear(7, 1)
@@ -69,6 +74,7 @@ func TestUnixTimestampForCorrespondingCurrentYear(t *testing.T) {
 }
 
 func TestUnixTimestampForCorrespondingCurrentYearMonth(t *testing.T) {
+	utils.Location = utils.UTCLocation()
 	got := utils.UnixTimestampForCorrespondingCurrentYearMonth(9) - utils.UnixTimestampForCorrespondingCurrentYearMonth(1)
 	utils.AssertEqual(t, got, 691200)
 	got = utils.UnixTimestampForCorrespondingCurrentYearMonth(28) - utils.UnixTimestampForCorrespondingCurrentYearMonth(1)


### PR DESCRIPTION
### Description

Use local time as the default

### Tasks

 - [ ] TODO items before it can be reviewed or merged
 - [ ] Another TODO item.

### Risks

- **Low**: Impacting only time display.
- Notes for Support:
- Notes for QA:
