### PR TITLE
Remove functionality to show done notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ With time, you will add more tags and hundreds of tasks under them. These **stat
 
 The above status states that there are currently 22 tags, a total of 330 tasks, and out of them 204 tasks are in the **"pending"** state. The tasks marked as **"done"** become **invisible** (but not deleted, and will still show up under **"Done Notes"** and in Search results).
 
-The **"Search Notes"** option lets you perform a **full-text search** (with each task's text and its comments) through all tasks with the **"pending"** state.
+The **"Search Notes"** option lets you perform a **full-text search** (with each task's status, text and its comments) through all tasks. You can use `[done]` as search text to filter only tasks which are done, similarly use `[pending]` for tasks which are pending.
 
 <p align="center">
   <img src="./assets/images/screen_search_01.png" width="100%">

--- a/cmd/reminder/main.go
+++ b/cmd/reminder/main.go
@@ -42,7 +42,6 @@ func flow() {
 		fmt.Sprintf("%v %v", utils.Symbols["spark"], "List Stuff"),
 		fmt.Sprintf("%v %v %v", utils.Symbols["checkerdFlag"], "Exit", utils.Symbols["redFlag"]),
 		fmt.Sprintf("%v %v", utils.Symbols["clock"], "Urgent Notes"),
-		fmt.Sprintf("%v %v", utils.Symbols["done"], "Done Notes"),
 		fmt.Sprintf("%v %v", utils.Symbols["search"], "Search Notes"),
 		fmt.Sprintf("%v %v", utils.Symbols["clip"], "Register Basic Tags"),
 		fmt.Sprintf("%v %v", utils.Symbols["backup"], "Create Backup"),


### PR DESCRIPTION
### Description

With the merge of https://github.com/goyalmunish/reminder/pull/79, explicit functionality to show done notes is no longer required.

### Tasks

 - [ ] TODO items before it can be reviewed or merged
 - [ ] Another TODO item.

### Risks

- **Low**: Removes only done functionality listing.
- Notes for Support:
- Notes for QA:
