### PR TITLE
Add functionality to set a note as main / non-main (incedental)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ _Apart from being **fully-interactive** and **terminal-based**, the other major 
     - can be **updated** (📝) with its text, and also can be enhanced with time-stamped **comments** (💬); so that you can track how and when the progress happened
     - can be marked **done** (✅) or **pending** (⏰); marking it as "done" makes it invisible
     - can be associated with **due-date** (📅); tasks with upcoming deadlines automatically show up under the **"~Pending~ Notes approaching Due Date"** option under **Main Menu**
+    - can be set as "main" or non-main (incidental)
 - **Full-text search** (🔎) among all tasks.
 - **Tag-groups** for grouping tags, for managing priority-levels (⬆️ ⬇️) or workflow-stages.
 - Provides you with **"Register Basic Tags"** functionality to seed basic tags which have special meaning to the workflow.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ _Apart from being **fully-interactive** and **terminal-based**, the other major 
 - A given task:
     - can be **updated** (📝) with its text, and also can be enhanced with time-stamped **comments** (💬); so that you can track how and when the progress happened
     - can be marked **done** (✅) or **pending** (⏰); marking it as "done" makes it invisible
-    - can be associated with **due-date** (📅); tasks with upcoming deadlines automatically show up under the **"~Pending~ Urgent Notes"** option under **Main Menu**
+    - can be associated with **due-date** (📅); tasks with upcoming deadlines automatically show up under the **"~Pending~ Notes approaching Due Date"** option under **Main Menu**
 - **Full-text search** (🔎) among all tasks.
 - **Tag-groups** for grouping tags, for managing priority-levels (⬆️ ⬇️) or workflow-stages.
 - Provides you with **"Register Basic Tags"** functionality to seed basic tags which have special meaning to the workflow.
@@ -71,7 +71,7 @@ Now, from within the **"List Stuff"** option, you can add a new tag using **"Add
 
 On selecting a tag (navigating to the tag and hitting **Enter** key), all of its tasks show up as a list of selectable items. You can then **navigate to a given task** and hit **Enter** key to bring up a **menu to update the task** (it lets you change its text, add comments, mark it as pending, mark it as done, add due-date, change its existing tag(s)). The following figures shows you how this menu looks like:
 
-Note: The **"~Pending~ Urgent Notes"** shows you tasks that require your immediate attention. In general, tasks with a **due-date** in upcoming `7` days start showing up under this option (and remain there until they are marked done). The tags **"repeat-monthly"** and **"repeat-annually"** are special; tasks tagged with them also show up under the **"~Pending~ Urgent Notes"** option close to their due-dates in their respective monthly and annual frequencies. These rules are also listed under **"~Pending~ Urgent Notes"** option as a reference.
+Note: The **"~Pending~ Notes approaching Due Date"** shows you tasks that require your immediate attention. In general, tasks with a **due-date** in upcoming `7` days start showing up under this option (and remain there until they are marked done). The tags **"repeat-monthly"** and **"repeat-annually"** are special; tasks tagged with them also show up under the **"~Pending~ Notes approaching Due Date"** option close to their due-dates in their respective monthly and annual frequencies. These rules are also listed under **"~Pending~ Notes approaching Due Date"** option as a reference.
 
 <p align="center">
   <img src="./assets/images/screen_search_04.png" width="100%">

--- a/cmd/reminder/main.go
+++ b/cmd/reminder/main.go
@@ -42,6 +42,7 @@ func flow() {
 		fmt.Sprintf("%v %v", utils.Symbols["spark"], "List Stuff"),
 		fmt.Sprintf("%v %v %v", utils.Symbols["checkerdFlag"], "Exit", utils.Symbols["redFlag"]),
 		fmt.Sprintf("%v %v", utils.Symbols["clock"], "Notes approaching Due Date"),
+		fmt.Sprintf("%v %v", utils.Symbols["clock"], "High Priority Notes"),
 		fmt.Sprintf("%v %v", utils.Symbols["search"], "Search Notes"),
 		fmt.Sprintf("%v %v", utils.Symbols["clip"], "Register Basic Tags"),
 		fmt.Sprintf("%v %v", utils.Symbols["backup"], "Create Backup"),
@@ -53,9 +54,11 @@ func flow() {
 	case fmt.Sprintf("%v %v", utils.Symbols["clip"], "Register Basic Tags"):
 		reminderData.RegisterBasicTags()
 	case fmt.Sprintf("%v %v", utils.Symbols["clock"], "Notes approaching Due Date"):
-		_ = reminderData.PrintNotesAndAskOptions(models.Notes{}, -1, "pending")
+		_ = reminderData.PrintNotesAndAskOptions(models.Notes{}, -1, "pending", false)
+	case fmt.Sprintf("%v %v", utils.Symbols["clock"], "High Priority Notes"):
+		_ = reminderData.PrintNotesAndAskOptions(models.Notes{}, -1, "pending", true)
 	case fmt.Sprintf("%v %v", utils.Symbols["done"], "Done Notes"):
-		_ = reminderData.PrintNotesAndAskOptions(models.Notes{}, -1, "done")
+		_ = reminderData.PrintNotesAndAskOptions(models.Notes{}, -1, "done", false)
 	case fmt.Sprintf("%v %v", utils.Symbols["search"], "Search Notes"):
 		_ = reminderData.SearchNotes()
 	case fmt.Sprintf("%v %v", utils.Symbols["backup"], "Create Backup"):

--- a/cmd/reminder/main.go
+++ b/cmd/reminder/main.go
@@ -42,7 +42,7 @@ func flow() {
 		fmt.Sprintf("%v %v", utils.Symbols["spark"], "List Stuff"),
 		fmt.Sprintf("%v %v %v", utils.Symbols["checkerdFlag"], "Exit", utils.Symbols["redFlag"]),
 		fmt.Sprintf("%v %v", utils.Symbols["clock"], "Notes approaching Due Date"),
-		fmt.Sprintf("%v %v", utils.Symbols["clock"], "Main Notes"),
+		fmt.Sprintf("%v %v", utils.Symbols["hat"], "Main Notes"),
 		fmt.Sprintf("%v %v", utils.Symbols["search"], "Search Notes"),
 		fmt.Sprintf("%v %v", utils.Symbols["clip"], "Register Basic Tags"),
 		fmt.Sprintf("%v %v", utils.Symbols["backup"], "Create Backup"),
@@ -55,7 +55,7 @@ func flow() {
 		reminderData.RegisterBasicTags()
 	case fmt.Sprintf("%v %v", utils.Symbols["clock"], "Notes approaching Due Date"):
 		_ = reminderData.PrintNotesAndAskOptions(models.Notes{}, -1, "pending", false)
-	case fmt.Sprintf("%v %v", utils.Symbols["clock"], "Main Notes"):
+	case fmt.Sprintf("%v %v", utils.Symbols["hat"], "Main Notes"):
 		_ = reminderData.PrintNotesAndAskOptions(models.Notes{}, -1, "pending", true)
 	case fmt.Sprintf("%v %v", utils.Symbols["done"], "Done Notes"):
 		_ = reminderData.PrintNotesAndAskOptions(models.Notes{}, -1, "done", false)

--- a/cmd/reminder/main.go
+++ b/cmd/reminder/main.go
@@ -42,7 +42,7 @@ func flow() {
 		fmt.Sprintf("%v %v", utils.Symbols["spark"], "List Stuff"),
 		fmt.Sprintf("%v %v %v", utils.Symbols["checkerdFlag"], "Exit", utils.Symbols["redFlag"]),
 		fmt.Sprintf("%v %v", utils.Symbols["clock"], "Notes approaching Due Date"),
-		fmt.Sprintf("%v %v", utils.Symbols["clock"], "High Priority Notes"),
+		fmt.Sprintf("%v %v", utils.Symbols["clock"], "Main Notes"),
 		fmt.Sprintf("%v %v", utils.Symbols["search"], "Search Notes"),
 		fmt.Sprintf("%v %v", utils.Symbols["clip"], "Register Basic Tags"),
 		fmt.Sprintf("%v %v", utils.Symbols["backup"], "Create Backup"),
@@ -55,7 +55,7 @@ func flow() {
 		reminderData.RegisterBasicTags()
 	case fmt.Sprintf("%v %v", utils.Symbols["clock"], "Notes approaching Due Date"):
 		_ = reminderData.PrintNotesAndAskOptions(models.Notes{}, -1, "pending", false)
-	case fmt.Sprintf("%v %v", utils.Symbols["clock"], "High Priority Notes"):
+	case fmt.Sprintf("%v %v", utils.Symbols["clock"], "Main Notes"):
 		_ = reminderData.PrintNotesAndAskOptions(models.Notes{}, -1, "pending", true)
 	case fmt.Sprintf("%v %v", utils.Symbols["done"], "Done Notes"):
 		_ = reminderData.PrintNotesAndAskOptions(models.Notes{}, -1, "done", false)

--- a/cmd/reminder/main.go
+++ b/cmd/reminder/main.go
@@ -41,7 +41,7 @@ func flow() {
 	_, result, _ := utils.AskOption([]string{
 		fmt.Sprintf("%v %v", utils.Symbols["spark"], "List Stuff"),
 		fmt.Sprintf("%v %v %v", utils.Symbols["checkerdFlag"], "Exit", utils.Symbols["redFlag"]),
-		fmt.Sprintf("%v %v", utils.Symbols["clock"], "Urgent Notes"),
+		fmt.Sprintf("%v %v", utils.Symbols["clock"], "Notes approaching Due Date"),
 		fmt.Sprintf("%v %v", utils.Symbols["search"], "Search Notes"),
 		fmt.Sprintf("%v %v", utils.Symbols["clip"], "Register Basic Tags"),
 		fmt.Sprintf("%v %v", utils.Symbols["backup"], "Create Backup"),
@@ -52,7 +52,7 @@ func flow() {
 		_ = reminderData.ListTags()
 	case fmt.Sprintf("%v %v", utils.Symbols["clip"], "Register Basic Tags"):
 		reminderData.RegisterBasicTags()
-	case fmt.Sprintf("%v %v", utils.Symbols["clock"], "Urgent Notes"):
+	case fmt.Sprintf("%v %v", utils.Symbols["clock"], "Notes approaching Due Date"):
 		_ = reminderData.PrintNotesAndAskOptions(models.Notes{}, -1, "pending")
 	case fmt.Sprintf("%v %v", utils.Symbols["done"], "Done Notes"):
 		_ = reminderData.PrintNotesAndAskOptions(models.Notes{}, -1, "done")

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module reminder
 
-go 1.17
+go 1.18
 
 require github.com/manifoldco/promptui v0.9.0
 

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,5 @@ require github.com/manifoldco/promptui v0.9.0
 
 require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
-	golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b // indirect
+	golang.org/x/sys v0.0.0-20210503173754-0981d6026fa6 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,5 +6,6 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWs
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/manifoldco/promptui v0.9.0 h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYthEiA=
 github.com/manifoldco/promptui v0.9.0/go.mod h1:ka04sppxSGFAtxX0qhlYQjISsg9mR4GWtQEhdbn6Pgg=
-golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b h1:MQE+LT/ABUuuvEZ+YQAMSXindAdUh7slEmAkup74op4=
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20210503173754-0981d6026fa6 h1:cdsMqa2nXzqlgs183pHxtvoVwU7CyzaCTAUOg94af4c=
+golang.org/x/sys v0.0.0-20210503173754-0981d6026fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -201,7 +201,7 @@ func TestNoteStrings(t *testing.T) {
   |              :  [nil] c3
    |        Status:  pending
    |          Tags:  [1 2]
-   |    IsPriority:  false
+   |        IsMain:  false
    |    CompleteBy:  Sunday, 03-Jan-21 10:20:35 UTC
    |     CreatedAt:  nil
    |     UpdatedAt:  nil
@@ -228,7 +228,7 @@ func TestExternalText(t *testing.T) {
   |          Tags:
   |              :  tag_1
   |              :  tag_2
-  |    IsPriority:  false
+  |        IsMain:  false
   |    CompleteBy:  Sunday, 03-Jan-21 10:20:35 UTC
   |     CreatedAt:  nil
   |     UpdatedAt:  nil
@@ -426,20 +426,20 @@ func TestUpdateStatus(t *testing.T) {
 	utils.AssertEqual(t, note1.Status, "pending")
 }
 
-func TestTogglePriority(t *testing.T) {
+func TestToggleMain(t *testing.T) {
 	// create notes
 	note1 := models.Note{Text: "original text", Status: "pending", TagIds: []int{1, 4}, BaseStruct: models.BaseStruct{UpdatedAt: 1600000001}}
 	// update TagIds
 	// case 1
-	originalPriority := note1.IsPriority
-	err := note1.TogglePriority()
+	originalPriority := note1.IsMain
+	err := note1.ToggleMain()
 	utils.AssertEqual(t, err, nil)
-	utils.AssertEqual(t, originalPriority != note1.IsPriority, true)
+	utils.AssertEqual(t, originalPriority != note1.IsMain, true)
 	// case 2
-	originalPriority = note1.IsPriority
-	err = note1.TogglePriority()
+	originalPriority = note1.IsMain
+	err = note1.ToggleMain()
 	utils.AssertEqual(t, err, nil)
-	utils.AssertEqual(t, originalPriority != note1.IsPriority, true)
+	utils.AssertEqual(t, originalPriority != note1.IsMain, true)
 }
 
 func TestFMakeSureFileExists(t *testing.T) {

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -201,6 +201,7 @@ func TestNoteStrings(t *testing.T) {
   |              :  [nil] c3
    |        Status:  pending
    |          Tags:  [1 2]
+   |    IsPriority:  false
    |    CompleteBy:  Sunday, 03-Jan-21 10:20:35 UTC
    |     CreatedAt:  nil
    |     UpdatedAt:  nil
@@ -227,6 +228,7 @@ func TestExternalText(t *testing.T) {
   |          Tags:
   |              :  tag_1
   |              :  tag_2
+  |    IsPriority:  false
   |    CompleteBy:  Sunday, 03-Jan-21 10:20:35 UTC
   |     CreatedAt:  nil
   |     UpdatedAt:  nil
@@ -422,6 +424,22 @@ func TestUpdateStatus(t *testing.T) {
 	err = note1.UpdateStatus("pending", []int{5, 6, 7})
 	utils.AssertEqual(t, err, nil)
 	utils.AssertEqual(t, note1.Status, "pending")
+}
+
+func TestTogglePriority(t *testing.T) {
+	// create notes
+	note1 := models.Note{Text: "original text", Status: "pending", TagIds: []int{1, 4}, BaseStruct: models.BaseStruct{UpdatedAt: 1600000001}}
+	// update TagIds
+	// case 1
+	originalPriority := note1.IsPriority
+	err := note1.TogglePriority()
+	utils.AssertEqual(t, err, nil)
+	utils.AssertEqual(t, originalPriority != note1.IsPriority, true)
+	// case 2
+	originalPriority = note1.IsPriority
+	err = note1.TogglePriority()
+	utils.AssertEqual(t, err, nil)
+	utils.AssertEqual(t, originalPriority != note1.IsPriority, true)
 }
 
 func TestFMakeSureFileExists(t *testing.T) {

--- a/internal/models/note.go
+++ b/internal/models/note.go
@@ -12,7 +12,7 @@ import (
 /*
 Note represents a task (a TO-DO item)
 
-A note can be main or main-note (incedental)
+A note can be main or main-note (incidental)
 */
 type Note struct {
 	Text       string   `json:"text"`

--- a/internal/models/note.go
+++ b/internal/models/note.go
@@ -191,6 +191,18 @@ func (notes Notes) WithStatus(status string) Notes {
 	}
 	return result
 }
+// filter notes with priority
+// return empty Notes if no priority Note is found
+func (notes Notes) WithPriority() Notes {
+	var result Notes
+	for _, note := range notes {
+		if note.IsPriority {
+			result = append(result, note)
+		}
+	}
+	return result
+}
+
 
 // get all notes with given tagID and given status
 // return empty Notes if no matching Note is found (even when given tagID or status doesn't exist)

--- a/internal/models/note.go
+++ b/internal/models/note.go
@@ -17,6 +17,7 @@ type Note struct {
 	Comments   Comments `json:"comments"`
 	Status     string   `json:"status"`
 	TagIds     []int    `json:"tag_ids"`
+	IsPriority bool     `json:"is_priority"`
 	CompleteBy int64    `json:"complete_by"`
 	BaseStruct
 }
@@ -36,6 +37,7 @@ func (note *Note) Strings() []string {
 	strs = append(strs, fPrintNoteField("Comments", note.Comments.Strings()))
 	strs = append(strs, fPrintNoteField("Status", note.Status))
 	strs = append(strs, fPrintNoteField("Tags", note.TagIds))
+	strs = append(strs, fPrintNoteField("IsPriority", note.IsPriority))
 	strs = append(strs, fPrintNoteField("CompleteBy", utils.UnixTimestampToLongTimeStr(note.CompleteBy)))
 	strs = append(strs, fPrintNoteField("CreatedAt", utils.UnixTimestampToLongTimeStr(note.CreatedAt)))
 	strs = append(strs, fPrintNoteField("UpdatedAt", utils.UnixTimestampToLongTimeStr(note.UpdatedAt)))
@@ -83,13 +85,12 @@ func (note *Note) AddComment(text string) error {
 	if len(utils.TrimString(text)) == 0 {
 		fmt.Printf("%v Skipping adding comment with empty text\n", utils.Symbols["warning"])
 		return errors.New("Note's comment text is empty")
-	} else {
-		comment := &Comment{Text: text, BaseStruct: BaseStruct{CreatedAt: utils.CurrentUnixTimestamp()}}
-		note.Comments = append(note.Comments, comment)
-		note.UpdatedAt = utils.CurrentUnixTimestamp()
-		fmt.Println("Updated the note")
-		return nil
 	}
+	comment := &Comment{Text: text, BaseStruct: BaseStruct{CreatedAt: utils.CurrentUnixTimestamp()}}
+	note.Comments = append(note.Comments, comment)
+	note.UpdatedAt = utils.CurrentUnixTimestamp()
+	fmt.Println("Updated the note")
+	return nil
 }
 
 // update note's text
@@ -97,33 +98,35 @@ func (note *Note) UpdateText(text string) error {
 	if len(utils.TrimString(text)) == 0 {
 		fmt.Printf("%v Skipping updating note with empty text\n", utils.Symbols["warning"])
 		return errors.New("Note's text is empty")
-	} else {
-		note.Text = text
-		note.UpdatedAt = utils.CurrentUnixTimestamp()
-		fmt.Println("Updated the note")
-		return nil
 	}
+	note.Text = text
+	note.UpdatedAt = utils.CurrentUnixTimestamp()
+	fmt.Println("Updated the note")
+	return nil
 }
 
 // update note's due date
 // if input is "nil", the existing due date is cleared
 func (note *Note) UpdateCompleteBy(text string) error {
+	// handle edge-case of empty text
 	if len(utils.TrimString(text)) == 0 {
 		fmt.Printf("%v Skipping updating note with empty due date\n", utils.Symbols["warning"])
 		return errors.New("Note's due date is empty")
-	} else if text == "nil" {
+	}
+	// handle edge-case for clearning the existing due date
+	if text == "nil" {
 		note.CompleteBy = 0
 		note.UpdatedAt = utils.CurrentUnixTimestamp()
 		fmt.Println("Cleared the due date from the note")
 		return nil
-	} else {
-		format := "2-1-2006"
-		timeValue, _ := time.Parse(format, text)
-		note.CompleteBy = int64(timeValue.Unix())
-		note.UpdatedAt = utils.CurrentUnixTimestamp()
-		fmt.Println("Updated the note with new due date")
-		return nil
 	}
+	// happy-path
+	format := "2-1-2006"
+	timeValue, _ := time.Parse(format, text)
+	note.CompleteBy = int64(timeValue.Unix())
+	note.UpdatedAt = utils.CurrentUnixTimestamp()
+	fmt.Println("Updated the note with new due date")
+	return nil
 }
 
 // update note's tags
@@ -147,6 +150,14 @@ func (note *Note) UpdateStatus(status string, repeatTagIDs []int) error {
 	} else {
 		fmt.Printf("%v Update skipped as there were no changes\n", utils.Symbols["warning"])
 	}
+	return nil
+}
+
+// toggle note's priority
+func (note *Note) TogglePriority() error {
+	note.IsPriority = !(note.IsPriority)
+	note.UpdatedAt = utils.CurrentUnixTimestamp()
+	fmt.Println("Updated the note's priority")
 	return nil
 }
 

--- a/internal/models/note.go
+++ b/internal/models/note.go
@@ -11,13 +11,15 @@ import (
 
 /*
 Note represents a task (a TO-DO item)
+
+A note can be main or main-note (incedental)
 */
 type Note struct {
 	Text       string   `json:"text"`
 	Comments   Comments `json:"comments"`
 	Status     string   `json:"status"`
 	TagIds     []int    `json:"tag_ids"`
-	IsPriority bool     `json:"is_priority"`
+	IsMain     bool     `json:"is_priority"`
 	CompleteBy int64    `json:"complete_by"`
 	BaseStruct
 }
@@ -37,7 +39,7 @@ func (note *Note) Strings() []string {
 	strs = append(strs, fPrintNoteField("Comments", note.Comments.Strings()))
 	strs = append(strs, fPrintNoteField("Status", note.Status))
 	strs = append(strs, fPrintNoteField("Tags", note.TagIds))
-	strs = append(strs, fPrintNoteField("IsPriority", note.IsPriority))
+	strs = append(strs, fPrintNoteField("IsMain", note.IsMain))
 	strs = append(strs, fPrintNoteField("CompleteBy", utils.UnixTimestampToLongTimeStr(note.CompleteBy)))
 	strs = append(strs, fPrintNoteField("CreatedAt", utils.UnixTimestampToLongTimeStr(note.CreatedAt)))
 	strs = append(strs, fPrintNoteField("UpdatedAt", utils.UnixTimestampToLongTimeStr(note.UpdatedAt)))
@@ -153,9 +155,9 @@ func (note *Note) UpdateStatus(status string, repeatTagIDs []int) error {
 	return nil
 }
 
-// toggle note's priority
-func (note *Note) TogglePriority() error {
-	note.IsPriority = !(note.IsPriority)
+// toggle note's main flag
+func (note *Note) ToggleMain() error {
+	note.IsMain = !(note.IsMain)
 	note.UpdatedAt = utils.CurrentUnixTimestamp()
 	fmt.Println("Updated the note's priority")
 	return nil
@@ -191,18 +193,18 @@ func (notes Notes) WithStatus(status string) Notes {
 	}
 	return result
 }
-// filter notes with priority
-// return empty Notes if no priority Note is found
-func (notes Notes) WithPriority() Notes {
+
+// filter notes which are set as main
+// return empty Notes if no main notes is found
+func (notes Notes) OnlyMain() Notes {
 	var result Notes
 	for _, note := range notes {
-		if note.IsPriority {
+		if note.IsMain {
 			result = append(result, note)
 		}
 	}
 	return result
 }
-
 
 // get all notes with given tagID and given status
 // return empty Notes if no matching Note is found (even when given tagID or status doesn't exist)

--- a/internal/models/reminder_data.go
+++ b/internal/models/reminder_data.go
@@ -141,6 +141,17 @@ func (reminderData *ReminderData) UpdateNoteStatus(note *Note, status string) er
 	return nil
 }
 
+// toggle note's priority
+func (reminderData *ReminderData) ToggleNotePriority(note *Note) error {
+	err := note.TogglePriority()
+	if err != nil {
+		return err
+	}
+	reminderData.UpdateDataFile()
+	fmt.Println("Updated the data file")
+	return nil
+}
+
 // register basic tags
 func (reminderData *ReminderData) RegisterBasicTags() {
 	if len(reminderData.Tags) == 0 {
@@ -500,7 +511,8 @@ func (reminderData *ReminderData) PrintNoteAndAskOptions(note *Note) string {
 		fmt.Sprintf("%v %v", utils.Symbols["downVote"], "Mark as pending"),
 		fmt.Sprintf("%v %v", utils.Symbols["calendar"], "Update due date"),
 		fmt.Sprintf("%v %v", utils.Symbols["tag"], "Update tags"),
-		fmt.Sprintf("%v %v", utils.Symbols["text"], "Update text")},
+		fmt.Sprintf("%v %v", utils.Symbols["text"], "Update text"),
+		fmt.Sprintf("%v %v", utils.Symbols["text"], "Toggle priority")},
 		"Select Action")
 	switch noteOption {
 	case fmt.Sprintf("%v %v", utils.Symbols["comment"], "Add comment"):
@@ -540,6 +552,9 @@ func (reminderData *ReminderData) PrintNoteAndAskOptions(note *Note) string {
 		} else {
 			fmt.Printf("%v Skipping updating note with empty tagIDs list\n", utils.Symbols["warning"])
 		}
+	case fmt.Sprintf("%v %v", utils.Symbols["text"], "Toggle priority"):
+		_ = reminderData.ToggleNotePriority(note)
+		fmt.Print(note.ExternalText(reminderData))
 	}
 	return "stay"
 }

--- a/internal/models/reminder_data.go
+++ b/internal/models/reminder_data.go
@@ -142,8 +142,8 @@ func (reminderData *ReminderData) UpdateNoteStatus(note *Note, status string) er
 }
 
 // toggle note's priority
-func (reminderData *ReminderData) ToggleNotePriority(note *Note) error {
-	err := note.TogglePriority()
+func (reminderData *ReminderData) ToggleNoteMainFlag(note *Note) error {
+	err := note.ToggleMain()
 	if err != nil {
 		return err
 	}
@@ -553,7 +553,7 @@ func (reminderData *ReminderData) PrintNoteAndAskOptions(note *Note) string {
 			fmt.Printf("%v Skipping updating note with empty tagIDs list\n", utils.Symbols["warning"])
 		}
 	case fmt.Sprintf("%v %v", utils.Symbols["text"], "Toggle priority"):
-		_ = reminderData.ToggleNotePriority(note)
+		_ = reminderData.ToggleNoteMainFlag(note)
 		fmt.Print(note.ExternalText(reminderData))
 	}
 	return "stay"
@@ -563,8 +563,8 @@ func (reminderData *ReminderData) PrintNoteAndAskOptions(note *Note) string {
 // in some cases, updated list notes will be fetched, so blank notes can be passed in those cases
 // unless notes are to be fetched, the passed `status` doesn't make sense, so in such cases it can be passed as "fake"
 // like utils.AskOptions, it prints any encountered error, and returns that error just for information
-// filter only notes with priority if `onlyPriority` is true, otherwise return all
-func (reminderData *ReminderData) PrintNotesAndAskOptions(notes Notes, tagID int, status string, onlyPriority bool) error {
+// filter only notes with priority if `onlyMain` is true, otherwise return all
+func (reminderData *ReminderData) PrintNotesAndAskOptions(notes Notes, tagID int, status string, onlyMain bool) error {
 	// check if passed notes is to be used or to fetch latest notes
 	if status == "done" {
 		// fetch all the done notes
@@ -586,9 +586,9 @@ func (reminderData *ReminderData) PrintNotesAndAskOptions(notes Notes, tagID int
 		// use passed notes
 		fmt.Printf("Using passed notes, so the list will not be refreshed immediately.\n")
 	}
-	// filter only priority notes if IsPriority is true
-	if onlyPriority == true {
-		notes = reminderData.Notes.WithPriority()
+	// filter only priority notes if IsMain is true
+	if onlyMain == true {
+		notes = reminderData.Notes.OnlyMain()
 	}
 	// sort notes
 	sort.Sort(Notes(notes))

--- a/internal/models/reminder_data.go
+++ b/internal/models/reminder_data.go
@@ -198,7 +198,7 @@ func (reminderData *ReminderData) ListTags() error {
 	}
 	// operate on the selected a tag
 	tag := reminderData.Tags[tagIndex]
-	err = reminderData.PrintNotesAndAskOptions(Notes{}, tag.Id, "pending")
+	err = reminderData.PrintNotesAndAskOptions(Notes{}, tag.Id, "pending", false)
 	if err != nil {
 		utils.PrintErrorIfPresent(err)
 		// go back to ListTags
@@ -563,7 +563,8 @@ func (reminderData *ReminderData) PrintNoteAndAskOptions(note *Note) string {
 // in some cases, updated list notes will be fetched, so blank notes can be passed in those cases
 // unless notes are to be fetched, the passed `status` doesn't make sense, so in such cases it can be passed as "fake"
 // like utils.AskOptions, it prints any encountered error, and returns that error just for information
-func (reminderData *ReminderData) PrintNotesAndAskOptions(notes Notes, tagID int, status string) error {
+// filter only notes with priority if `onlyPriority` is true, otherwise return all
+func (reminderData *ReminderData) PrintNotesAndAskOptions(notes Notes, tagID int, status string, onlyPriority bool) error {
 	// check if passed notes is to be used or to fetch latest notes
 	if status == "done" {
 		// fetch all the done notes
@@ -584,6 +585,10 @@ func (reminderData *ReminderData) PrintNotesAndAskOptions(notes Notes, tagID int
 	} else {
 		// use passed notes
 		fmt.Printf("Using passed notes, so the list will not be refreshed immediately.\n")
+	}
+	// filter only priority notes if IsPriority is true
+	if onlyPriority == true {
+		notes = reminderData.Notes.WithPriority()
 	}
 	// sort notes
 	sort.Sort(Notes(notes))
@@ -614,7 +619,7 @@ func (reminderData *ReminderData) PrintNotesAndAskOptions(notes Notes, tagID int
 		var updatedNotes Notes
 		updatedNotes = append(updatedNotes, note)
 		updatedNotes = append(updatedNotes, notes...)
-		reminderData.PrintNotesAndAskOptions(updatedNotes, tagID, status)
+		reminderData.PrintNotesAndAskOptions(updatedNotes, tagID, status, false)
 		return nil
 	}
 	// ask options about the selected note
@@ -622,7 +627,7 @@ func (reminderData *ReminderData) PrintNotesAndAskOptions(notes Notes, tagID int
 	action := reminderData.PrintNoteAndAskOptions(note)
 	if action == "stay" {
 		// no action was selected for the note, go one step back
-		reminderData.PrintNotesAndAskOptions(notes, tagID, status)
+		reminderData.PrintNotesAndAskOptions(notes, tagID, status, false)
 	}
 	return nil
 }

--- a/pkg/utils/symbols.go
+++ b/pkg/utils/symbols.go
@@ -24,4 +24,5 @@ var Symbols = map[string]string{
 	"add":          "➕",
 	"backup":       "💾",
 	"zzz":          "💤",
+	"hat":          "🎩",
 }


### PR DESCRIPTION
### Description

Add functionality to set a note as main / non-main (incidental)

Addressing part of the issue https://github.com/goyalmunish/reminder/issues/77

### Tasks

 - [ ] TODO items before it can be reviewed or merged
 - [ ] Another TODO item.

### Risks

- **Low**: Doesn't impact existing functionality
- Notes for Support:
- Notes for QA:
