### PR TITLE
Further filter main notes by status

### DIFF
--- a/cmd/reminder/main.go
+++ b/cmd/reminder/main.go
@@ -57,8 +57,6 @@ func flow() {
 		_ = reminderData.PrintNotesAndAskOptions(models.Notes{}, -1, "pending", false)
 	case fmt.Sprintf("%v %v", utils.Symbols["hat"], "Main Notes"):
 		_ = reminderData.PrintNotesAndAskOptions(models.Notes{}, -1, "pending", true)
-	case fmt.Sprintf("%v %v", utils.Symbols["done"], "Done Notes"):
-		_ = reminderData.PrintNotesAndAskOptions(models.Notes{}, -1, "done", false)
 	case fmt.Sprintf("%v %v", utils.Symbols["search"], "Search Notes"):
 		_ = reminderData.SearchNotes()
 	case fmt.Sprintf("%v %v", utils.Symbols["backup"], "Create Backup"):

--- a/internal/models/note.go
+++ b/internal/models/note.go
@@ -3,6 +3,7 @@ package models
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -74,9 +75,12 @@ func (note *Note) SearchableText() string {
 		commentsText = append(commentsText, strings.Join(note.Comments.Strings(), ", "))
 	}
 	commentsText = append(commentsText, "]")
+	// get main-flag and status
+	mainFlag := fmt.Sprintf("[ IsMain=%s ]", strconv.FormatBool(note.IsMain))
+	noteStatus := fmt.Sprintf("[ %s ]", note.Status)
 	// get a complete searchable text array for note
 	var searchableText []string
-	noteStatus := "[" + note.Status + "]"
+	searchableText = append(searchableText, mainFlag)
 	searchableText = append(searchableText, noteStatus)
 	searchableText = append(searchableText, note.Text)
 	searchableText = append(searchableText, note.Summary)


### PR DESCRIPTION
### Description

Further filter main notes by status

### Tasks

 - [ ] TODO items before it can be reviewed or merged
 - [ ] Another TODO item.

### Risks

- **Medium**: Touch existing functionality of listing main notes and searching all notes
- Notes for Support:
- Notes for QA:
