### PR TITLE
Use Go 1.18 for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.2-alpine3.14
+FROM golang:1.18.0-alpine3.14
 
 ENV DIR_HOME=/root
 ENV DIR_DATA /data

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
-mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
-repo_name := $(notdir $(patsubst %/,%,$(dir $(mkfile_path))))
+mkfile_name := $(lastword $(MAKEFILE_LIST))
+mkfile_path := $(abspath $(mkfile_name))
+repo_path := $(realpath $(dir $(mkfile_path)))
+repo_name := $(notdir ${repo_path})
 
 .PHONY: build
 build:

--- a/dev_guide.md
+++ b/dev_guide.md
@@ -6,6 +6,7 @@
     - [How to run in development mode?](#how-to-run-in-development-mode)
     - [Run Tests](#run-tests)
     - [Format Files](#format-files)
+    - [Linting Code](#linting-code)
     - [Debugging Program](#debugging-program)
     - [Build Docker Image](#build-docker-image)
     - [Additional Conventions](#additional-conventions)
@@ -22,14 +23,14 @@ Here's how you can run in development mode:
 cd reminder/
 
 # way 1
-go run cmd/reminder/main.go
+go run ./cmd/reminder
 
 # way 2
 cd cmd/reminder
 go run .
 
 # way 3
-. ./scripts/go_run
+make -s run
 ```
 
 ## Run Tests
@@ -44,6 +45,9 @@ cd reminder/
 
 # run tests without supressing printing to console
 CONSOLE_PRINT=true . ./scripts/go_test
+
+# or, using make
+make -s test
 ```
 
 ## Format Files
@@ -54,6 +58,15 @@ You can make use of [`go_fmt`](./scripts/go_fmt) to auto-format all `.go` files:
 cd reminder/
 
 . ./scripts/go_fmt
+
+# or using make
+make -s fmt
+```
+
+## Linting Code
+
+```sh
+make -s lint
 ```
 
 ## Debugging Program


### PR DESCRIPTION
### Description

Use Go 1.18 for Docker

### Tasks

 - [ ] TODO items before it can be reviewed or merged
 - [ ] Another TODO item.

### Risks

- **Low**: Impacts only the Docker image
- Notes for Support:
- Notes for QA:
