### PR TITLE
Use the current year if year part is missing

### DIFF
--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -430,7 +430,7 @@ func TestUpdateStatus(t *testing.T) {
 	// update TagIds
 	// case 1
 	err := note1.UpdateStatus("done", []int{1, 2, 3})
-	utils.AssertEqual(t, err, nil)
+	utils.AssertEqual(t, err, errors.New("Note is part of a \"repeat\" group"))
 	utils.AssertEqual(t, note1.Status, "pending")
 	// case 2
 	err = note1.UpdateStatus("done", []int{5, 6, 7})

--- a/internal/model/note.go
+++ b/internal/model/note.go
@@ -175,6 +175,13 @@ func (note *Note) UpdateCompleteBy(text string) error {
 		defer fmt.Println("Cleared the due date from the note")
 	} else {
 		format := "2-1-2006"
+		// set current year as year if year part is missing
+		year := utils.CurrentTime().Year()
+		timeSplit := strings.Split(text, "-")
+		if len(timeSplit) == 2 {
+			text = fmt.Sprintf("%s-%d", text, year)
+		}
+		// parse and set the date
 		timeValue, _ := time.Parse(format, text)
 		note.CompleteBy = int64(timeValue.Unix())
 		defer fmt.Println("Updated the note with new due date")

--- a/internal/model/note.go
+++ b/internal/model/note.go
@@ -92,7 +92,6 @@ func (note *Note) SearchableText() string {
 // AddComment adds a new comment to note.
 func (note *Note) AddComment(text string) error {
 	if len(utils.TrimString(text)) == 0 {
-		fmt.Printf("%v Skipping adding comment with empty text\n", utils.Symbols["warning"])
 		return errors.New("Note's comment text is empty")
 	}
 	comment := &Comment{Text: text, BaseStruct: BaseStruct{CreatedAt: utils.CurrentUnixTimestamp()}}
@@ -117,12 +116,10 @@ func (note *Note) UpdateTags(tagIDs []int) error {
 func (note *Note) UpdateStatus(status string, repeatTagIDs []int) error {
 	noteIDsWithRepeat := utils.GetCommonMembersIntSlices(note.TagIds, repeatTagIDs)
 	if len(noteIDsWithRepeat) != 0 {
-		fmt.Printf("%v Update skipped as one of the associated tag is a \"repeat\" group tag \n", utils.Symbols["warning"])
-		return nil
+		return errors.New("Note is part of a \"repeat\" group")
 	}
 	if note.Status == status {
-		fmt.Printf("%v Update skipped as there were no changes\n", utils.Symbols["warning"])
-		return nil
+		return errors.New("Desired status is same as existing one")
 	}
 	// happy path
 	note.Status = status
@@ -136,7 +133,6 @@ func (note *Note) UpdateStatus(status string, repeatTagIDs []int) error {
 // Once updated, the text cannot be made empty.
 func (note *Note) UpdateText(text string) error {
 	if len(utils.TrimString(text)) == 0 {
-		fmt.Printf("%v Skipping updating note with empty text\n", utils.Symbols["warning"])
 		return errors.New("Note's text is empty")
 	}
 	// happy path
@@ -151,7 +147,6 @@ func (note *Note) UpdateText(text string) error {
 // If input is "nil", the existing summary is cleared.
 func (note *Note) UpdateSummary(text string) error {
 	if len(utils.TrimString(text)) == 0 {
-		fmt.Printf("%v Skipping updating note with empty summary\n", utils.Symbols["warning"])
 		return errors.New("Note's summary is empty")
 	}
 	// happy path
@@ -172,7 +167,6 @@ func (note *Note) UpdateSummary(text string) error {
 func (note *Note) UpdateCompleteBy(text string) error {
 	// handle edge-case of empty text
 	if len(utils.TrimString(text)) == 0 {
-		fmt.Printf("%v Skipping updating note with empty due date\n", utils.Symbols["warning"])
 		return errors.New("Note's due date is empty")
 	}
 	// happy path

--- a/internal/model/reminder_data.go
+++ b/internal/model/reminder_data.go
@@ -37,8 +37,11 @@ func (reminderData *ReminderData) UpdateDataFile(msg string) error {
 	reminderData.UpdatedAt = utils.CurrentUnixTimestamp()
 	// marshal the data
 	byteValue, err := json.MarshalIndent(&reminderData, "", "    ")
-	utils.PrintErrorIfPresent(err)
-	// commit the byte data to file
+	if err != nil {
+		utils.PrintErrorIfPresent(err)
+		return err
+	}
+	// persist the byte data to file
 	err = ioutil.WriteFile(reminderData.DataFile, byteValue, 0755)
 	if err != nil {
 		utils.PrintErrorIfPresent(err)
@@ -162,7 +165,7 @@ func (reminderData *ReminderData) RegisterBasicTags() error {
 	}
 	basicTags := BasicTags()
 	reminderData.Tags = basicTags
-	msg := fmt.Sprintf("Added basic tags: %v\n", reminderData.Tags)
+	msg := fmt.Sprintf("Added basic tags: %+v\n", reminderData.Tags)
 	return reminderData.UpdateDataFile(msg)
 }
 

--- a/pkg/utils/functions.go
+++ b/pkg/utils/functions.go
@@ -162,11 +162,11 @@ func ValidateNonEmptyString(input string) error {
 	}
 }
 
-// ValidateDateString function validates date string (DD-MM-YYYY).
+// ValidateDateString function validates date string (DD-MM-YYYY) or (DD-MM).
 // nil is also valid input
 func ValidateDateString(input string) error {
 	input = TrimString(input)
-	re := regexp.MustCompile("^((0?[1-9]|[12][0-9]|3[01])-(0?[1-9]|1[012])-((19|20)\\d\\d)|(nil))$")
+	re := regexp.MustCompile("^((0?[1-9]|[12][0-9]|3[01])-(0?[1-9]|1[012])(-((19|20)\\d\\d))?|(nil))$")
 	if re.MatchString(input) {
 		return nil
 	} else {
@@ -375,7 +375,7 @@ func GeneratePrompt(promptName string, defaultText string) *promptui.Prompt {
 		}
 	case "note_completed_by":
 		prompt = &promptui.Prompt{
-			Label:    "Due Date (format: DD-MM-YYYY), or enter nil to clear existing value",
+			Label:    "Due Date (format: DD-MM-YYYY or DD-MM), or enter nil to clear existing value",
 			Default:  defaultText,
 			Validate: ValidateDateString,
 		}


### PR DESCRIPTION
### Description

Use the current year if year part is missing

### Tasks

 - [ ] TODO items before it can be reviewed or merged
 - [ ] Another TODO item.

### Risks

- **Low**: Impacts only the due date functionality
- Notes for Support:
- Notes for QA:
