### PR TITLE
Minimize printing errors outside main.go

### DIFF
--- a/cmd/reminder/main.go
+++ b/cmd/reminder/main.go
@@ -36,6 +36,7 @@ func flow() {
 		But, if you are inside PromptUI's `Run()`, then it cancels the input and moves to next
 		statement in the code.
 	*/
+	var err error
 	_, result, _ := utils.AskOption([]string{
 		fmt.Sprintf("%v %v", utils.Symbols["spark"], "List Stuff"),
 		fmt.Sprintf("%v %v %v", utils.Symbols["checkerdFlag"], "Exit", utils.Symbols["redFlag"]),
@@ -48,23 +49,24 @@ func flow() {
 	// operate on main options
 	switch result {
 	case fmt.Sprintf("%v %v", utils.Symbols["spark"], "List Stuff"):
-		_ = reminderData.ListTags()
+		err = reminderData.ListTags()
 	case fmt.Sprintf("%v %v", utils.Symbols["clip"], "Register Basic Tags"):
-		_ = reminderData.RegisterBasicTags()
+		err = reminderData.RegisterBasicTags()
 	case fmt.Sprintf("%v %v", utils.Symbols["clock"], "Approaching Due Date"):
-		_ = reminderData.PrintNotesAndAskOptions(model.Notes{}, -1, "pending", false)
+		err = reminderData.PrintNotesAndAskOptions(model.Notes{}, -1, "pending", false)
 	case fmt.Sprintf("%v %v", utils.Symbols["hat"], "Main Notes"):
-		_ = reminderData.PrintNotesAndAskOptions(model.Notes{}, -1, "pending", true)
+		err = reminderData.PrintNotesAndAskOptions(model.Notes{}, -1, "pending", true)
 	case fmt.Sprintf("%v %v", utils.Symbols["search"], "Search Notes"):
-		_ = reminderData.SearchNotes()
+		err = reminderData.SearchNotes()
 	case fmt.Sprintf("%v %v", utils.Symbols["backup"], "Create Backup"):
-		_ = reminderData.CreateBackup()
+		_, err = reminderData.CreateBackup()
 	case fmt.Sprintf("%v %v", utils.Symbols["pad"], "Display Data File"):
-		_ = reminderData.DisplayDataFile()
+		err = reminderData.DisplayDataFile()
 	case fmt.Sprintf("%v %v %v", utils.Symbols["checkerdFlag"], "Exit", utils.Symbols["redFlag"]):
 		fmt.Println("Exiting...")
 		return
 	}
+	utils.PrintErrorIfPresent(err)
 	flow()
 }
 

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,5 @@ require github.com/manifoldco/promptui v0.9.0
 
 require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
-	golang.org/x/sys v0.0.0-20210503173754-0981d6026fa6 // indirect
+	golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,5 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWs
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/manifoldco/promptui v0.9.0 h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYthEiA=
 github.com/manifoldco/promptui v0.9.0/go.mod h1:ka04sppxSGFAtxX0qhlYQjISsg9mR4GWtQEhdbn6Pgg=
+golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b h1:MQE+LT/ABUuuvEZ+YQAMSXindAdUh7slEmAkup74op4=
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20210503173754-0981d6026fa6 h1:cdsMqa2nXzqlgs183pHxtvoVwU7CyzaCTAUOg94af4c=
-golang.org/x/sys v0.0.0-20210503173754-0981d6026fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/model/reminder_data.go
+++ b/internal/model/reminder_data.go
@@ -165,8 +165,8 @@ func (reminderData *ReminderData) ToggleNoteMainFlag(note *Note) error {
 // RegisterBasicTags registers basic tags.
 func (reminderData *ReminderData) RegisterBasicTags() error {
 	if len(reminderData.Tags) != 0 {
-		fmt.Printf("%v Skipped registering basic tags as tag list is not empty\n", utils.Symbols["warning"])
-		return nil
+		msg := fmt.Sprintf("%v Skipped registering basic tags as tag list is not empty\n", utils.Symbols["warning"])
+		return errors.New(msg)
 	}
 	basicTags := BasicTags()
 	reminderData.Tags = basicTags
@@ -247,7 +247,6 @@ func (reminderData *ReminderData) SearchNotes() error {
 	fmt.Printf("Searching through a total of %v notes:\n", len(allTexts))
 	index, _, err := promptNoteSelection.Run()
 	if err != nil {
-		utils.PrintErrorIfPresent(err)
 		return err
 	}
 	if index >= 0 {
@@ -462,7 +461,6 @@ func (reminderData *ReminderData) DisplayDataFile() error {
 			err = utils.PerformCwdiff(lnFile, reminderData.DataFile)
 		}
 	}
-	utils.PrintErrorIfPresent(err)
 	return err
 }
 
@@ -659,7 +657,6 @@ func (reminderData *ReminderData) PrintNotesAndAskOptions(notes Notes, tagID int
 		}
 		note, err := reminderData.NewNoteRegistration([]int{tagID})
 		if err != nil {
-			utils.PrintErrorIfPresent(err)
 			return err
 		}
 		var updatedNotes Notes


### PR DESCRIPTION
### Description

Minimize printing errors outside `main.go`

### Tasks

 - [ ] TODO items before it can be reviewed or merged
 - [ ] Another TODO item.

### Risks

- **Low**: No change of functionality, except the movement of printing of errors.
- Notes for Support:
- Notes for QA:
