### PR TITLE
Fix searchable text containing newlines

### DIFF
--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -254,6 +254,11 @@ func TestSearchableText(t *testing.T) {
 	note = model.Note{Text: "a cute dog", Comments: comments}
 	got = note.SearchableText()
 	utils.AssertEqual(t, got, "| incidental |         | a cute dog  [no-comments]")
+	// case 4
+	comments = model.Comments{}
+	note = model.Note{Text: "first line\nsecondline\nthird line", Comments: comments}
+	got = note.SearchableText()
+	utils.AssertEqual(t, got, "| incidental |         | first line NWL secondline NWL third line  [no-comments]")
 }
 
 func TestExternalTexts(t *testing.T) {

--- a/internal/model/note.go
+++ b/internal/model/note.go
@@ -85,8 +85,12 @@ func (note *Note) SearchableText() string {
 	searchableText = append(searchableText, note.Text)
 	searchableText = append(searchableText, note.Summary)
 	searchableText = append(searchableText, strings.Join(commentsText, ""))
+	// form a single string
+	text := strings.Join(searchableText, " ")
+	// address some special characters
+	text = strings.ReplaceAll(text, "\n", " NWL ")
 	// return searchable text for note a string
-	return strings.Join(searchableText, " ")
+	return text
 }
 
 // AddComment adds a new comment to note.


### PR DESCRIPTION
### Description

Fix searchable text containing newlines

### Tasks

 - [ ] TODO items before it can be reviewed or merged
 - [ ] Another TODO item.

### Risks

- **Low**: Impacts only search text functionality
- Notes for Support:
- Notes for QA:
