### PR TITLE
Try fixing brew tap integration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,4 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Your GoReleaser Pro key, if you are using the 'goreleaser-pro'
-          # distribution:
-          # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,6 +36,7 @@ brews:
     tap:
       owner: goyalmunish
       name: homebrew-reminder
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
       branch: main
     url_template: >-
       https://github.com/goyalmunish/munish/releases/download/{{ .Tag }}/{{


### PR DESCRIPTION
### Description

Try fixing the brew tap integration

Refer: https://goreleaser.com/errors/resource-not-accessible-by-integration/

### Tasks

NA

### Risks

- **Low**: Impacts github actions
- Notes for Support:
- Notes for QA:
