### PR TITLE
Fallback to default configuration if app configuration is not found

### DIFF
--- a/internal/settings/config.go
+++ b/internal/settings/config.go
@@ -36,14 +36,16 @@ func LoadConfig(ctx context.Context) (*Settings, error) {
 	settings := DefaultSettings()
 	viper.SetConfigType("yaml")
 	viper.SetConfigFile(appConfigPath)
+	logger.Info(ctx, fmt.Sprintf("Attempt to read the app config %q (on top of default values).", appConfigPath))
 	if err := viper.ReadInConfig(); err != nil {
+		// Just log the error, and fall back to default settings.
 		utils.LogError(ctx, err)
-		return nil, err
 	}
+	// If config file is found, unmarshal those values ontop of default settings struct.
+	// Otherwise, do nothing.
 	if err := viper.Unmarshal(settings); err != nil {
 		utils.LogError(ctx, err)
 		return nil, err
 	}
-	logger.Info(ctx, fmt.Sprintf("Read the app config %q (on top of default values).", appConfigPath))
 	return settings, nil
 }


### PR DESCRIPTION
### Description

Fallback to default configuration if app configuration is not found. At present, the configuration file makes sense only in dev workflow.

```
ERRO[0000] ❌ open ./config/default.yaml: no such file or directory panic: open ./config/default.yaml: no such file or directory

goroutine 1 [running]:
github.com/goyalmunish/reminder/cmd/reminder.init.0()
        /home/runner/work/reminder/reminder/cmd/reminder/main.go:30 +0x2a4
```

### Tasks

NA

### Risks

- **Low**: Fix the issue of an unfound configuration file.
- Notes for Support:
- Notes for QA:
