### PR TITLE
Sync only the nodes with pending status and with due-date

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
             - [Install `go`](#install-go)
             - [Install the tool (optional)](#install-the-tool-optional)
             - [Run the tool](#run-the-tool)
+    - [Setting up the environment for Google Calendar Sync](#setting-up-the-environment-for-google-calendar-sync)
     - [Features/Issues to be worked upon](#featuresissues-to-be-worked-upon)
     - [Contributing towards development](#contributing-towards-development)
 
@@ -119,10 +120,10 @@ brew tap goyalmunish/reminder
 brew install goyalmunish/reminder/reminder
 ```
 
-To update:
+To upgrade to latest `reminder` version:
 
 ```sh
-brew update goyalmunish/reminder/reminder
+brew upgrade goyalmunish/reminder/reminder
 ```
 
 The brew tap is maintained at [goyalmunish/homebrew-reminder](https://github.com/goyalmunish/homebrew-reminder).
@@ -228,6 +229,13 @@ make run
 # or as
 go run ./cmd/reminder
 ```
+
+## Setting up the environment for Google Calendar Sync
+
+As you are owner and also the end user, you would need to follow instructions on Google's official doc of [Set up your environment](https://developers.google.com/calendar/api/quickstart/go#set_up_your_environment) to:
+
+- [Enable the API](https://console.cloud.google.com/flows/enableapi?apiid=calendar-json.googleapis.com)
+- Save [credentials](https://console.cloud.google.com/apis/credentials) to **`~/calendar_credentials.json`** file.
 
 ## Features/Issues to be worked upon
 

--- a/dev_guide.md
+++ b/dev_guide.md
@@ -89,7 +89,7 @@ VERSION=v1.0.0
 
 Refer:
 
-- [Setup Your Environment](https://developers.google.com/calendar/api/quickstart/go#set_up_your_environment)
+- [Setting up the environment for Google Calendar Sync](./README.md#setting-up-the-environment-for-google-calendar-sync)
 - [Go Quickstart](https://developers.google.com/calendar/api/quickstart/go)
 - [pkg `calendar`](https://pkg.go.dev/google.golang.org/api/calendar/v3)
 - [Calendar API Reference](https://developers.google.com/calendar/api/v3/reference)

--- a/internal/model/functions.go
+++ b/internal/model/functions.go
@@ -269,7 +269,7 @@ func ReadDataFile(ctx context.Context, dataFilePath string) *ReminderData {
 	utils.LogError(ctx, err)
 	// parse json data
 	err = json.Unmarshal(byteValue, &reminderData)
-	logger.Info(ctx, fmt.Sprintf("Read contents of %q into ReminderData", dataFilePath))
+	logger.Info(ctx, fmt.Sprintf("Read contents of %q into ReminderData.", dataFilePath))
 	utils.LogError(ctx, err)
 	// set context
 	reminderData.SetContext(ctx)

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -334,6 +334,26 @@ func TestWithStatus(t *testing.T) {
 	utils.AssertEqual(t, got, want)
 }
 
+func TestWithCompleteBy(t *testing.T) {
+	var notes model.Notes
+	// case 1 (no notes)
+	utils.AssertEqual(t, notes.WithCompleteBy(), model.Notes{})
+	// add some notes
+	comments := model.Comments{&model.Comment{Text: "c1"}}
+	note1 := model.Note{Text: "big fat cat", Comments: comments, Status: model.NoteStatus_Pending, TagIds: []int{1, 2}, CompleteBy: 1609669231}
+	notes = append(notes, &note1)
+	comments = model.Comments{&model.Comment{Text: "c1"}, &model.Comment{Text: "foo bar"}}
+	note2 := model.Note{Text: "cute brown dog", Comments: comments, Status: model.NoteStatus_Done, TagIds: []int{1, 3}, CompleteBy: 1609669232}
+	notes = append(notes, &note2)
+	comments = model.Comments{&model.Comment{Text: "foo bar"}, &model.Comment{Text: "c3"}}
+	note3 := model.Note{Text: "little hamster", Comments: comments, Status: model.NoteStatus_Pending, TagIds: []int{1}}
+	notes = append(notes, &note3)
+	// case 3 (with only few notes to be filtered in)
+	got := notes.WithCompleteBy()
+	want := model.Notes{&note1, &note2}
+	utils.AssertEqual(t, got, want)
+}
+
 func TestWithTagIdAndStatus(t *testing.T) {
 	// var tags model.Tags
 	var notes model.Notes

--- a/internal/model/note.go
+++ b/internal/model/note.go
@@ -125,7 +125,7 @@ func (note *Note) AddComment(text string) error {
 	}
 	comment := &Comment{Text: text, BaseStruct: BaseStruct{CreatedAt: utils.CurrentUnixTimestamp()}}
 	note.Comments = append(note.Comments, comment)
-	defer logger.Info(note.context, fmt.Sprintln("Added the comment"))
+	defer logger.Info(note.context, fmt.Sprintln("Added the comment."))
 	// update the UpdatedAt as well
 	note.UpdatedAt = utils.CurrentUnixTimestamp()
 	return nil
@@ -134,7 +134,7 @@ func (note *Note) AddComment(text string) error {
 // UpdateTags updates note's tags.
 func (note *Note) UpdateTags(tagIDs []int) error {
 	note.TagIds = tagIDs
-	defer logger.Info(note.context, fmt.Sprintln("Updated the note with tags"))
+	defer logger.Info(note.context, fmt.Sprintln("Updated the note with tags."))
 	// update the UpdatedAt as well
 	note.UpdatedAt = utils.CurrentUnixTimestamp()
 	return nil
@@ -152,7 +152,7 @@ func (note *Note) UpdateStatus(status NoteStatus, repeatTagIDs []int) error {
 	}
 	// happy path
 	note.Status = status
-	defer logger.Info(note.context, fmt.Sprintln("Updated the status"))
+	defer logger.Info(note.context, fmt.Sprintln("Updated the status."))
 	// update the UpdatedAt as well
 	note.UpdatedAt = utils.CurrentUnixTimestamp()
 	return nil
@@ -166,7 +166,7 @@ func (note *Note) UpdateText(text string) error {
 	}
 	// happy path
 	note.Text = text
-	defer logger.Info(note.context, fmt.Sprintln("Updated the text"))
+	defer logger.Info(note.context, fmt.Sprintln("Updated the text."))
 	// update the UpdatedAt as well
 	note.UpdatedAt = utils.CurrentUnixTimestamp()
 	return nil
@@ -181,10 +181,10 @@ func (note *Note) UpdateSummary(text string) error {
 	// happy path
 	if text == "nil" {
 		note.Summary = ""
-		defer logger.Info(note.context, fmt.Sprintln("Cleared the due date from the note"))
+		defer logger.Info(note.context, fmt.Sprintln("Cleared the due date from the note."))
 	} else {
 		note.Summary = text
-		defer logger.Info(note.context, fmt.Sprintln("Updated the summary"))
+		defer logger.Info(note.context, fmt.Sprintln("Updated the summary."))
 	}
 	// update the UpdatedAt as well
 	note.UpdatedAt = utils.CurrentUnixTimestamp()
@@ -201,7 +201,7 @@ func (note *Note) UpdateCompleteBy(text string) error {
 	// happy path
 	if text == "nil" {
 		note.CompleteBy = 0
-		defer logger.Info(note.context, fmt.Sprintln("Cleared the due date from the note"))
+		defer logger.Info(note.context, fmt.Sprintln("Cleared the due date from the note."))
 	} else {
 		format := "2-1-2006"
 		// set current year as year if year part is missing
@@ -216,7 +216,7 @@ func (note *Note) UpdateCompleteBy(text string) error {
 		// parse and set the date
 		timeValue, _ := time.Parse(format, text)
 		note.CompleteBy = int64(timeValue.Unix())
-		defer logger.Info(note.context, fmt.Sprintln("Updated the note with new due date"))
+		defer logger.Info(note.context, fmt.Sprintln("Updated the note with new due date."))
 	}
 	// update the UpdatedAt as well
 	note.UpdatedAt = utils.CurrentUnixTimestamp()
@@ -238,7 +238,7 @@ func (note *Note) RepeatType(repeatAnnuallyTagId int, repeatMonthlyTagId int) st
 // ToggleMainFlag toggles note's main flag.
 func (note *Note) ToggleMainFlag() error {
 	note.IsMain = !(note.IsMain)
-	defer logger.Info(note.context, fmt.Sprintln("Toggled the note's main/incedental flag"))
+	defer logger.Info(note.context, fmt.Sprintln("Toggled the note's main/incedental flag."))
 	// update the UpdatedAt as well
 	note.UpdatedAt = utils.CurrentUnixTimestamp()
 	return nil

--- a/internal/model/note.go
+++ b/internal/model/note.go
@@ -249,7 +249,7 @@ func (note *Note) GoogleCalendarEvent(repeatAnnuallyTagId int, repeatMonthlyTagI
 	// basic information
 	title := note.Text
 	description := ""                                                    // don't expose comments for data privacy
-	start := utils.UnixTimestampToTime(note.CompleteBy + int64(9*60*60)) // register events for 9 AM of the day
+	start := utils.UnixTimestampToTime(note.CompleteBy - int64(20*60*60)) // workaround to adjust for current day (later, need to take into account timezone in CompleteBy)
 	repeatType := note.RepeatType(repeatAnnuallyTagId, repeatMonthlyTagId)
 
 	// lego the information

--- a/internal/model/note.go
+++ b/internal/model/note.go
@@ -248,7 +248,7 @@ func (note *Note) ToggleMainFlag() error {
 func (note *Note) GoogleCalendarEvent(repeatAnnuallyTagId int, repeatMonthlyTagId int, timezoneIANA string) *gc.Event {
 	// basic information
 	title := note.Text
-	description := ""                                                    // don't expose comments for data privacy
+	description := ""                                                     // don't expose comments for data privacy
 	start := utils.UnixTimestampToTime(note.CompleteBy - int64(20*60*60)) // workaround to adjust for current day (later, need to take into account timezone in CompleteBy)
 	repeatType := note.RepeatType(repeatAnnuallyTagId, repeatMonthlyTagId)
 

--- a/internal/model/notes.go
+++ b/internal/model/notes.go
@@ -41,12 +41,24 @@ func (notes Notes) ExternalTexts(maxStrLen int, repeatAnnuallyTagId int, repeatM
 	return allTexts
 }
 
-// WithStatus filters notes with given status (such as "pending" status).
+// WithStatus filters-in notes with given status (such as "pending" status).
 // It returns empty Notes if no matching Note is found (even when given status doesn't exist).
 func (notes Notes) WithStatus(status NoteStatus) Notes {
 	var result Notes
 	for _, note := range notes {
 		if note.Status == status {
+			result = append(result, note)
+		}
+	}
+	return result
+}
+
+// WithCompleteBy filters-in only notes with non-nil CompleteBy filed of the notes.
+// It returns empty Notes if no matching Note is found (even when given status doesn't exist).
+func (notes Notes) WithCompleteBy() Notes {
+	var result Notes
+	for _, note := range notes {
+		if note.CompleteBy > 0 {
 			result = append(result, note)
 		}
 	}


### PR DESCRIPTION
### Description

- Update doc and instructions for Calendar Sync
- Sync only the nodes with pending status and with due-date
- Introduce 30s waiting for the user before syncing
- Workaround for Cloud Calendar event time; Later, we need to make sure it to happen based on the timezone.

### Tasks

NA

### Risks

- **Low**: Updating just docs, log messages, and an additional filter.
- Notes for Support:
- Notes for QA:
